### PR TITLE
Hiding tasks which are not required in Release Service and cleaning up help text

### DIFF
--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "Ant",
     "description": "Build with Apache Ant",
     "category": "Build",
+    "visibility": [
+                "Build"
+                  ],    
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Build",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,

--- a/Tasks/AndroidBuild/task.json
+++ b/Tasks/AndroidBuild/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "Android Build",
     "description": "Build an Android app using Gradle and optionally start the emulator for unit tests",
     "category": "Build",
+    "visibility": [
+                "Build"
+                  ],   
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,

--- a/Tasks/AndroidBuild/task.loc.json
+++ b/Tasks/AndroidBuild/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Build",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,

--- a/Tasks/AndroidSigning/task.json
+++ b/Tasks/AndroidSigning/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "Android Signing",
     "description": "Sign and align Android APK files",
     "category": "Build",
+    "visibility": [
+                "Build"
+                  ],    
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,

--- a/Tasks/AndroidSigning/task.loc.json
+++ b/Tasks/AndroidSigning/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Build",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,

--- a/Tasks/AzureCloudPowerShellDeployment/task.json
+++ b/Tasks/AzureCloudPowerShellDeployment/task.json
@@ -4,6 +4,10 @@
   "friendlyName": "Azure Cloud Service Deployment",
   "description": "Deploy an Azure Cloud Service",
   "category": "Deploy",
+  "visibility": [
+                "Build",
+                "Release"
+                ],  
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
@@ -49,15 +53,17 @@
       "name": "CsPkg",
       "type": "string",
       "label": "CsPkg",
-      "defaultValue": "$(build.stagingDirectory)\\*.cspkg",
-      "required": true
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Path of CsPkg under the default artifact directory of the agent."
     },
     {
       "name": "CsCfg",
       "type": "string",
       "label": "CsCfg",
-      "defaultValue": "$(build.stagingDirectory)\\*.cscfg",
-      "required": true
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Path of CsCfg under the default artifact directory of the agent."
     },
     {
       "name": "Slot",

--- a/Tasks/AzureCloudPowerShellDeployment/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeployment/task.loc.json
@@ -7,6 +7,10 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Deploy",
+  "visibility": [
+    "Build",
+    "Release"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
@@ -52,15 +56,17 @@
       "name": "CsPkg",
       "type": "string",
       "label": "ms-resource:loc.input.label.CsPkg",
-      "defaultValue": "$(build.stagingDirectory)\\*.cspkg",
-      "required": true
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Path of CsPkg under the default artifact directory of the agent."
     },
     {
       "name": "CsCfg",
       "type": "string",
       "label": "ms-resource:loc.input.label.CsCfg",
-      "defaultValue": "$(build.stagingDirectory)\\*.cscfg",
-      "required": true
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Path of CsCfg under the default artifact directory of the agent."
     },
     {
       "name": "Slot",

--- a/Tasks/AzurePowerShell/task.json
+++ b/Tasks/AzurePowerShell/task.json
@@ -4,6 +4,10 @@
     "friendlyName": "Azure PowerShell",
     "description": "Run a PowerShell script within an Azure environment",
     "category": "Deploy",
+    "visibility": [
+                  "Build",
+                  "Release"
+                  ],    
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
@@ -28,7 +32,7 @@
             "label": "Script Path",
             "defaultValue": "",
             "required": true,
-            "helpMarkDown": "Relative path from the repo root of the script to run."
+            "helpMarkDown": "Path of the script relative to the default working directory of the agent."
         },
         {
             "name": "ScriptArguments",

--- a/Tasks/AzurePowerShell/task.loc.json
+++ b/Tasks/AzurePowerShell/task.loc.json
@@ -7,6 +7,10 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Deploy",
+  "visibility": [
+    "Build",
+    "Release"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
@@ -31,7 +35,7 @@
       "label": "ms-resource:loc.input.label.ScriptPath",
       "defaultValue": "",
       "required": true,
-      "helpMarkDown": "Relative path from the repo root of the script to run."
+      "helpMarkDown": "Path of the script relative to the default working directory of the agent."
     },
     {
       "name": "ScriptArguments",

--- a/Tasks/AzureWebPowerShellDeployment/task.json
+++ b/Tasks/AzureWebPowerShellDeployment/task.json
@@ -4,6 +4,10 @@
   "friendlyName": "Azure Web Site Deployment",
   "description": "Deploy a website to Microsoft Azure",
   "category": "Deploy",
+  "visibility": [
+                "Build",
+                "Release"
+                ],  
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
@@ -41,7 +45,7 @@
       "name": "Package",
       "type": "string",
       "label": "Package",
-      "defaultValue": "$(build.stagingDirectory)\\*.zip",
+      "defaultValue": "Path of package under the default artifact directory of the agent.",
       "required": true
     },
     {

--- a/Tasks/AzureWebPowerShellDeployment/task.loc.json
+++ b/Tasks/AzureWebPowerShellDeployment/task.loc.json
@@ -7,6 +7,10 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Deploy",
+  "visibility": [
+    "Build",
+    "Release"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
@@ -44,7 +48,7 @@
       "name": "Package",
       "type": "string",
       "label": "ms-resource:loc.input.label.Package",
-      "defaultValue": "$(build.stagingDirectory)\\*.zip",
+      "defaultValue": "Path of package under the default artifact directory of the agent.",
       "required": true
     },
     {

--- a/Tasks/BatchScript/task.json
+++ b/Tasks/BatchScript/task.json
@@ -4,6 +4,10 @@
     "friendlyName": "Batch Script",
     "description": "Run a windows cmd or bat script and optionally allow it to change the environment",
     "category": "Utility",
+    "visibility": [
+                  "Build",
+                  "Release"
+                  ],    
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
@@ -27,7 +31,7 @@
             "label": "Path",
             "defaultValue":"",
             "required": true,
-            "helpMarkDown": "Relative path from repo root of the cmd or bat script file to run."
+            "helpMarkDown": "Path of the cmd or bat script to execute relative to the default working directory of the agent."
         },
         {
             "name": "arguments",

--- a/Tasks/BatchScript/task.loc.json
+++ b/Tasks/BatchScript/task.loc.json
@@ -7,6 +7,10 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Utility",
+  "visibility": [
+    "Build",
+    "Release"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
@@ -30,7 +34,7 @@
       "label": "ms-resource:loc.input.label.filename",
       "defaultValue": "",
       "required": true,
-      "helpMarkDown": "Relative path from repo root of the cmd or bat script file to run."
+      "helpMarkDown": "Path of the cmd or bat script to execute relative to the default working directory of the agent."
     },
     {
       "name": "arguments",

--- a/Tasks/CMake/task.json
+++ b/Tasks/CMake/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "CMake",
     "description": "Build with the CMake cross-platform build system",
     "category": "Build",
+    "visibility": [
+                "Build"
+                  ],    
     "author": "Microsoft Corporation",
     "demands" : [
         "cmake"

--- a/Tasks/CMake/task.loc.json
+++ b/Tasks/CMake/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Build",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "demands": [
     "cmake"

--- a/Tasks/CmdLine/task.json
+++ b/Tasks/CmdLine/task.json
@@ -4,6 +4,10 @@
     "friendlyName": "Command Line",
     "description": "Run a command line with arguments",
     "category": "Utility",
+    "visibility": [
+                  "Build",
+                  "Release"
+                  ],    
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,

--- a/Tasks/CmdLine/task.loc.json
+++ b/Tasks/CmdLine/task.loc.json
@@ -7,6 +7,10 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Utility",
+  "visibility": [
+    "Build",
+    "Release"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,

--- a/Tasks/CocoaPods/task.json
+++ b/Tasks/CocoaPods/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "CocoaPods",
     "description": "CocoaPods is the dependency manager for Swift and Objective-C Cocoa projects. Runs pod install.",
     "category": "Package",
+    "visibility": [
+                "Build"
+                  ],    
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,

--- a/Tasks/CocoaPods/task.loc.json
+++ b/Tasks/CocoaPods/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Package",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,

--- a/Tasks/DeployTestAgent/task.json
+++ b/Tasks/DeployTestAgent/task.json
@@ -6,7 +6,8 @@
     "category": "Test",
     "visibility": [
                 "Preview",
-                "Build"
+                "Build",
+                "Release"
                   ],
     "author": "Microsoft Corporation",
     "version": {

--- a/Tasks/DeployTestAgent/task.loc.json
+++ b/Tasks/DeployTestAgent/task.loc.json
@@ -9,7 +9,8 @@
   "category": "Test",
   "visibility": [
     "Preview",
-    "Build"
+    "Build",
+    "Release"
   ],
   "author": "Microsoft Corporation",
   "version": {

--- a/Tasks/DeployToTfsEnvironment/task.json
+++ b/Tasks/DeployToTfsEnvironment/task.json
@@ -6,7 +6,8 @@
     "category": "Deploy",
     "visibility": [
                 "Preview",
-                "Build"
+                "Build",
+                "Release"
                   ],
     "author": "Microsoft Corporation",
     "version": {
@@ -37,7 +38,7 @@
             "label": "Source",
             "defaultValue": "",
             "required": true,
-            "helpMarkDown": "Location of the application binaries. Variables like $(Build.Repository.LocalPath) can be used for binaries in the Automation Agent. For example, $(Build.Repository.LocalPath)\\BudgetIT\\Web." 
+            "helpMarkDown": "Location of the application binaries under the default working directory of the agent." 
         },
         {
             "name": "ApplicationPath",

--- a/Tasks/DeployToTfsEnvironment/task.loc.json
+++ b/Tasks/DeployToTfsEnvironment/task.loc.json
@@ -9,7 +9,8 @@
   "category": "Deploy",
   "visibility": [
     "Preview",
-    "Build"
+    "Build",
+    "Release"
   ],
   "author": "Microsoft Corporation",
   "version": {
@@ -40,7 +41,7 @@
       "label": "ms-resource:loc.input.label.SourcePackage",
       "defaultValue": "",
       "required": true,
-      "helpMarkDown": "Location of the application binaries. Variables like $(Build.Repository.LocalPath) can be used for binaries in the Automation Agent. For example, $(Build.Repository.LocalPath)\\BudgetIT\\Web."
+      "helpMarkDown": "Location of the application binaries under the default working directory of the agent."
     },
     {
       "name": "ApplicationPath",

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "Gradle",
     "description": "Build using a Gradle wrapper script",
     "category": "Build",
+    "visibility": [
+                "Build"
+                  ],    
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,

--- a/Tasks/Gradle/task.loc.json
+++ b/Tasks/Gradle/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Build",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,

--- a/Tasks/Gulp/task.json
+++ b/Tasks/Gulp/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "Gulp",
     "description": "Build with a Node.js streaming, task-based build system",
     "category": "Build",
+    "visibility": [
+                "Build"
+                  ],    
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,

--- a/Tasks/Gulp/task.loc.json
+++ b/Tasks/Gulp/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Build",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,

--- a/Tasks/MSBuild/task.json
+++ b/Tasks/MSBuild/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "MSBuild",
     "description": "Build with MSBuild",
     "category": "Build",
+    "visibility": [
+                "Build"
+                  ],    
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,

--- a/Tasks/MSBuild/task.loc.json
+++ b/Tasks/MSBuild/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Build",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "Maven",
     "description": "Build with Apache Maven",
     "category": "Build",
+    "visibility": [
+                "Build"
+                  ],    
     "author": "Microsoft Corporation",
     "demands" : [
         "maven"

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Build",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "demands": [
     "maven"

--- a/Tasks/RunDistributedTests/task.json
+++ b/Tasks/RunDistributedTests/task.json
@@ -6,7 +6,8 @@
     "category": "Test",
     "visibility": [
                 "Preview",
-                "Build"
+                "Build",
+                "Release"
                   ],
     "author": "Microsoft Corporation",
     "version": {

--- a/Tasks/RunDistributedTests/task.loc.json
+++ b/Tasks/RunDistributedTests/task.loc.json
@@ -9,7 +9,8 @@
   "category": "Test",
   "visibility": [
     "Preview",
-    "Build"
+    "Build",
+    "Release"
   ],
   "author": "Microsoft Corporation",
   "version": {

--- a/Tasks/ShellScript/task.json
+++ b/Tasks/ShellScript/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "Shell Script",
     "description": "Run a shell script using bash",
     "category": "Utility",
+    "visibility": [
+                "Build"
+                  ],
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,

--- a/Tasks/ShellScript/task.loc.json
+++ b/Tasks/ShellScript/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Utility",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,

--- a/Tasks/VSBuild/task.json
+++ b/Tasks/VSBuild/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "Visual Studio Build",
     "description": "Build with MSBuild in the Visual Studio Developer Command Prompt",
     "category": "Build",
+    "visibility": [
+                "Build"
+                  ],
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,

--- a/Tasks/VSBuild/task.loc.json
+++ b/Tasks/VSBuild/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Build",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -4,6 +4,10 @@
   "friendlyName": "Visual Studio Test",
   "description": "Run tests with Visual Studio test runner",
   "category": "Test",
+  "visibility": [
+                "Build",
+                "Release"
+                ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -7,6 +7,10 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Test",
+  "visibility": [
+    "Build",
+    "Release"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,

--- a/Tasks/XamarinAndroid/task.json
+++ b/Tasks/XamarinAndroid/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "Xamarin Android",
     "description": "Build an Android app with Xamarin",
     "category": "Build",
+    "visibility": [
+                "Build"
+                  ],
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,

--- a/Tasks/XamarinAndroid/task.loc.json
+++ b/Tasks/XamarinAndroid/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Build",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,

--- a/Tasks/XamarinLicense/task.json
+++ b/Tasks/XamarinLicense/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "Xamarin License",
     "description": "Activate or deactivate Xamarin licenses",
     "category": "Utility",
+    "visibility": [
+                "Build"
+                  ],
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,

--- a/Tasks/XamarinLicense/task.loc.json
+++ b/Tasks/XamarinLicense/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Utility",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,

--- a/Tasks/XamarinTestCloud/task.json
+++ b/Tasks/XamarinTestCloud/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "Xamarin Test Cloud",
     "description": "Test mobile apps with Xamarin Test Cloud using Xamarin.UITest",
     "category": "Test",
+    "visibility": [
+                "Build"
+                  ],
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,

--- a/Tasks/XamarinTestCloud/task.loc.json
+++ b/Tasks/XamarinTestCloud/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Test",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,

--- a/Tasks/XamariniOS/task.json
+++ b/Tasks/XamariniOS/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "Xamarin iOS",
     "description": "Build an iOS app with Xamarin on Mac OS",
     "category": "Build",
+    "visibility": [
+                "Build"
+                  ],
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,

--- a/Tasks/XamariniOS/task.loc.json
+++ b/Tasks/XamariniOS/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Build",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,

--- a/Tasks/Xcode/task.json
+++ b/Tasks/Xcode/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "Xcode Build",
     "description": "Build an Xcode workspace on Mac OS",
     "category": "Build",
+    "visibility": [
+                "Build"
+                  ],
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,

--- a/Tasks/Xcode/task.loc.json
+++ b/Tasks/Xcode/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Build",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,

--- a/Tasks/XcodePackageiOS/task.json
+++ b/Tasks/XcodePackageiOS/task.json
@@ -4,6 +4,9 @@
     "friendlyName": "Xcode Package iOS",
     "description": "Generate an .ipa file from Xcode build output",
     "category": "Build",
+    "visibility": [
+                "Build"
+                  ],
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,

--- a/Tasks/XcodePackageiOS/task.loc.json
+++ b/Tasks/XcodePackageiOS/task.loc.json
@@ -7,6 +7,9 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Build",
+  "visibility": [
+    "Build"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,

--- a/Tasks/powerShell/task.json
+++ b/Tasks/powerShell/task.json
@@ -4,6 +4,10 @@
     "friendlyName": "PowerShell",
     "description": "Run a PowerShell script",
     "category": "Utility",
+    "visibility": [
+                  "Build",
+                  "Release"
+                  ],    
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
@@ -27,7 +31,7 @@
             "label": "Script filename", 
             "defaultValue":"", 
             "required":true,
-            "helpMarkDown": "Relative path from repo root of the PowerShell script file to run." 
+            "helpMarkDown": "Path of the script to execute relative to the default working directory of the agent." 
         },
         { 
             "name": "arguments", 

--- a/Tasks/powerShell/task.loc.json
+++ b/Tasks/powerShell/task.loc.json
@@ -7,6 +7,10 @@
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
   "category": "Utility",
+  "visibility": [
+    "Build",
+    "Release"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
@@ -30,7 +34,7 @@
       "label": "ms-resource:loc.input.label.scriptName",
       "defaultValue": "",
       "required": true,
-      "helpMarkDown": "Relative path from repo root of the PowerShell script file to run."
+      "helpMarkDown": "Path of the script to execute relative to the default working directory of the agent."
     },
     {
       "name": "arguments",


### PR DESCRIPTION
 - Hiding tasks which are not required in Release Service.
 - Cleaning up help to apply for both Build and Release Service.
 - Removing build specific default values.