### PR TITLE
Changing Azure tasks to use newly added connectedService:Azure type

### DIFF
--- a/Tasks/AzureCloudPowerShellDeployment/task.json
+++ b/Tasks/AzureCloudPowerShellDeployment/task.json
@@ -16,7 +16,7 @@
   "inputs": [
     {
       "name": "ConnectedServiceName",
-      "type": "azureConnection",
+      "type": "connectedService:Azure",
       "label": "Azure Subscription",
       "defaultValue": "",
       "required": true,

--- a/Tasks/AzureCloudPowerShellDeployment/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeployment/task.loc.json
@@ -19,7 +19,7 @@
   "inputs": [
     {
       "name": "ConnectedServiceName",
-      "type": "azureConnection",
+      "type": "connectedService:Azure",
       "label": "ms-resource:loc.input.label.ConnectedServiceName",
       "defaultValue": "",
       "required": true,

--- a/Tasks/AzurePowerShell/task.json
+++ b/Tasks/AzurePowerShell/task.json
@@ -16,7 +16,7 @@
     "inputs": [
         {
             "name": "ConnectedServiceName",
-            "type": "azureConnection",
+            "type": "connectedService:Azure",
             "label": "Azure Subscription",
             "defaultValue": "",
             "required": true,

--- a/Tasks/AzurePowerShell/task.loc.json
+++ b/Tasks/AzurePowerShell/task.loc.json
@@ -19,7 +19,7 @@
   "inputs": [
     {
       "name": "ConnectedServiceName",
-      "type": "azureConnection",
+      "type": "connectedService:Azure",
       "label": "ms-resource:loc.input.label.ConnectedServiceName",
       "defaultValue": "",
       "required": true,

--- a/Tasks/AzureWebPowerShellDeployment/task.json
+++ b/Tasks/AzureWebPowerShellDeployment/task.json
@@ -16,7 +16,7 @@
   "inputs": [
     {
       "name": "ConnectedServiceName",
-      "type": "azureConnection",
+      "type": "connectedService:Azure",
       "label": "Azure Subscription",
       "defaultValue": "",
       "required": true,

--- a/Tasks/AzureWebPowerShellDeployment/task.loc.json
+++ b/Tasks/AzureWebPowerShellDeployment/task.loc.json
@@ -19,7 +19,7 @@
   "inputs": [
     {
       "name": "ConnectedServiceName",
-      "type": "azureConnection",
+      "type": "connectedService:Azure",
       "label": "ms-resource:loc.input.label.ConnectedServiceName",
       "defaultValue": "",
       "required": true,


### PR DESCRIPTION
Changing Azure tasks to use newly connectedService:Azure type so that connected service details are consumed from job endpoint via GetConnectedServiceDetailsCmdlet