### PR TITLE
Fixing the chef generic task so that script path can now contain spaces

### DIFF
--- a/Tasks/ChefKnife/ChefKnife.ps1
+++ b/Tasks/ChefKnife/ChefKnife.ps1
@@ -19,7 +19,7 @@ Import-Module "Microsoft.TeamFoundation.DistributedTask.Task.Deployment.Chef"
 Write-Host "ScriptArguments= " $ScriptArguments
 Write-Host "ScriptPath= " $ScriptPath
 
-$scriptCommand = "$ScriptPath $scriptArguments"
+$scriptCommand = "& `"$ScriptPath`" $scriptArguments"
 Write-Host "scriptCommand=" $scriptCommand
 
 try


### PR DESCRIPTION
- If the script path contained spaces the task would not run as expected. Fixing that.