### PR TITLE
Fixing the azure powershell task to take script paths with spaces in it

### DIFF
--- a/Tasks/AzurePowerShell/RunAzurePowerShell.ps1
+++ b/Tasks/AzurePowerShell/RunAzurePowerShell.ps1
@@ -17,7 +17,7 @@ Write-Host "Entering script RunAzurePowerShell.ps1"
 Write-Host "ScriptArguments= " $ScriptArguments
 Write-Host "ScriptPath= " $ScriptPath
 
-$scriptCommand = "$ScriptPath $scriptArguments"
+$scriptCommand = "& `"$ScriptPath`" $scriptArguments"
 Write-Host "scriptCommand=" $scriptCommand
 Invoke-Expression -Command $scriptCommand
 


### PR DESCRIPTION
- Fixing the azure powershell task to now take script paths with spaces in it