### PR TITLE
Fixing chef task to now call Get-ServiceEndpoint

### DIFF
--- a/Tasks/Chef/Chef.ps1
+++ b/Tasks/Chef/Chef.ps1
@@ -150,7 +150,7 @@ try
     Import-Module "Microsoft.TeamFoundation.DistributedTask.Task.Deployment.Chef"
 
     #fetching chef subscription details
-    $connectedServiceDetails = Get-ConnectedServiceDetails -Context $distributedTaskContext -ConnectedServiceName $connectedServiceName
+    $connectedServiceDetails = Get-ServiceEndpoint -Context $distributedTaskContext -Name $connectedServiceName
 
 	#setting up chef repo with the chef subscription details fetched before
     Setup-ChefRepo $connectedServiceDetails

--- a/Tasks/ChefKnife/ChefKnife.ps1
+++ b/Tasks/ChefKnife/ChefKnife.ps1
@@ -25,7 +25,7 @@ Write-Host "scriptCommand=" $scriptCommand
 try
 {
     #fetching chef subscription details 
-    $connectedServiceDetails = Get-ConnectedServiceDetails -Context $distributedTaskContext -ConnectedServiceName $connectedServiceName
+    $connectedServiceDetails = Get-ServiceEndpoint -Context $distributedTaskContext -Name $connectedServiceName
     #setting up chef repo with the chef subscription details fetched before 
     Setup-ChefRepo $connectedServiceDetails 
     Invoke-Expression -Command $scriptCommand


### PR DESCRIPTION
1. Fixing the chef task to now call the Get-ServiceEndpoint cmdlet instead of the Get-ConnectedServiceDetails cmdlet.
2. Making the fix in the chef generic task as well.