### PR TITLE
Adding demands and fixing verb notations of cmdlets

### DIFF
--- a/Tasks/Chef/Chef.ps1
+++ b/Tasks/Chef/Chef.ps1
@@ -153,7 +153,7 @@ try
     $connectedServiceDetails = Get-ConnectedServiceDetails -Context $distributedTaskContext -ConnectedServiceName $connectedServiceName
 
 	#setting up chef repo with the chef subscription details fetched before
-    Setup-ChefRepo $connectedServiceDetails
+    Initialize-ChefRepo $connectedServiceDetails
 
 	#this is the poll interval for checking in between runs
 	$pollIntervalForRunsInSeconds = 60;

--- a/Tasks/Chef/task.json
+++ b/Tasks/Chef/task.json
@@ -16,6 +16,10 @@
         "Patch": 1,
         "IsTest": false
     },
+    "demands" : [
+        "Chef",
+        "KnifeReporting"
+    ],
     "inputs": [
         {
             "name": "connectedServiceName",

--- a/Tasks/Chef/task.loc.json
+++ b/Tasks/Chef/task.loc.json
@@ -19,6 +19,10 @@
     "Patch": 1,
     "IsTest": false
   },
+  "demands": [
+    "Chef",
+    "KnifeReporting"
+  ],
   "inputs": [
     {
       "name": "connectedServiceName",

--- a/Tasks/ChefKnife/ChefKnife.ps1
+++ b/Tasks/ChefKnife/ChefKnife.ps1
@@ -27,7 +27,7 @@ try
     #fetching chef subscription details 
     $connectedServiceDetails = Get-ConnectedServiceDetails -Context $distributedTaskContext -ConnectedServiceName $connectedServiceName
     #setting up chef repo with the chef subscription details fetched before 
-    Setup-ChefRepo $connectedServiceDetails 
+    Initialize-ChefRepo $connectedServiceDetails 
     Invoke-Expression -Command $scriptCommand
 }
 finally

--- a/Tasks/ChefKnife/task.json
+++ b/Tasks/ChefKnife/task.json
@@ -15,6 +15,9 @@
         "Minor": 0,
         "Patch": 0
     },
+    "demands" : [
+        "Chef"
+    ],
     "inputs": [
         {
             "name": "ConnectedServiceName",

--- a/Tasks/ChefKnife/task.loc.json
+++ b/Tasks/ChefKnife/task.loc.json
@@ -18,6 +18,9 @@
     "Minor": 0,
     "Patch": 0
   },
+  "demands": [
+    "Chef"
+  ],
   "inputs": [
     {
       "name": "ConnectedServiceName",


### PR DESCRIPTION
Now adding demands of 'Chef' and 'KnifeReporting' to the ChefTask and only 'Chef' demand to the chef generic task. Modified the task to now call the proper convention cmdlets in the chef powershell module.