### PR TITLE
Check NugetRestore flag before writing warning

### DIFF
--- a/Tasks/MSBuild/MSBuild.ps1
+++ b/Tasks/MSBuild/MSBuild.ps1
@@ -98,7 +98,7 @@ if ($cleanBuild)
 }
 
 $nugetPath = Get-ToolPath -Name 'NuGet.exe'
-if (-not $nugetPath)
+if (-not $nugetPath -and $nugetRestore)
 {
     Write-Warning "Unable to locate nuget.exe. Package restore will not be performed for the solutions"
 }

--- a/Tasks/MSBuild/task.json
+++ b/Tasks/MSBuild/task.json
@@ -11,7 +11,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 7
+        "Patch": 8
     },
     "demands" : [
         "msbuild"

--- a/Tasks/MSBuild/task.loc.json
+++ b/Tasks/MSBuild/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 7
+    "Patch": 8
   },
   "demands": [
     "msbuild"

--- a/Tasks/VSBuild/VSBuild.ps1
+++ b/Tasks/VSBuild/VSBuild.ps1
@@ -128,7 +128,7 @@ if ($cleanBuild)
 }
 
 $nugetPath = Get-ToolPath -Name 'NuGet.exe'
-if (-not $nugetPath)
+if (-not $nugetPath -and $nugetRestore)
 {
     Write-Warning "Unable to locate nuget.exe. Package restore will not be performed for the solutions"
 }

--- a/Tasks/VSBuild/task.json
+++ b/Tasks/VSBuild/task.json
@@ -11,7 +11,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 7
+        "Patch": 8
     },
     "demands": [
         "msbuild",

--- a/Tasks/VSBuild/task.loc.json
+++ b/Tasks/VSBuild/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 7
+    "Patch": 8
   },
   "demands": [
     "msbuild",


### PR DESCRIPTION
If nuget.exe isn't in the Tools folder on the agent, we *always* emit a
warning that we can't find it and that package restore won't be
performed.  We emit this warning even if the MSBuild/VSBuild task has
the nuget restore option unchecked.  So now we'll only emit the warning
if we can't find nuget.exe *and* the option is checked.