### PR TITLE
Users/siddhap/win7tainstall

### DIFF
--- a/Tasks/DeployTestAgent/TestAgentInstall.ps1
+++ b/Tasks/DeployTestAgent/TestAgentInstall.ps1
@@ -16,8 +16,6 @@ function Install-Product($SetupPath, $UserName, $Password, $ProductVersion, $Arg
 	{
 		Write-Verbose -Message ("Installing/Updating Test Agent.") -verbose
 
-		$creds = New-Object System.Management.Automation.PSCredential -ArgumentList $UserName, (ConvertTo-SecureString -String $Password -AsPlainText -Force)
-
 		# Invoke the TA installation
 		Write-Verbose -Message ("Invoking the command {0} with arguments {1}" -f $SetupPath, $Arguments) -verbose
 

--- a/Tasks/DeployTestAgent/TestAgentInstall.ps1
+++ b/Tasks/DeployTestAgent/TestAgentInstall.ps1
@@ -24,7 +24,7 @@ function Install-Product($SetupPath, $UserName, $Password, $ProductVersion, $Arg
 		try
 		{
 			$argumentsarr = $Arguments -split " "
-			$exitCode = Invoke-Command -ScriptBlock { cmd.exe /c $args[0] $args[1]; $LASTEXITCODE } -ArgumentList $SetupPath,$argumentsarr -ComputerName . -Credential $creds -ErrorAction Stop
+			$exitCode = Invoke-Command -ScriptBlock { cmd.exe /c $args[0] $args[1]; $LASTEXITCODE } -ArgumentList $SetupPath,$argumentsarr -ErrorAction Stop
 		}
 		catch
 		{


### PR DESCRIPTION
Somehow this checkin didnt go in. The fix was suggested by Pavan.

"If we specify –ComputerName and –Credentials, then PS is creating a new
session with the provided credentials to the given host.
This is nothing but remote execution of given command. In our case, it
is execution of TestAgent.exe remotely.
As we have observed, Win7 still has issue with remote execution of .NET.
So, I thought of removing the above options so that PS executes in the
current session" -- Pavan.
Tested the fix on windows 7 machine