### PR TITLE
Fixing Chef Environment having no nodes in it

### DIFF
--- a/Tasks/Chef/Chef.ps1
+++ b/Tasks/Chef/Chef.ps1
@@ -24,6 +24,12 @@ function Validate-EnvironmentInput()
 	{
 		throw "Environment name `"$environment`" is not found on the chef server"	
 	}
+
+    $nodesList = Invoke-Knife @("node list -E $environmentName")
+    if([string]::isNullOrEmpty($nodesList))
+    {
+        throw "The chef environment: `"$environment`" has no nodes in it"	
+    }
 }
 
 function Validate-AttributesInput()


### PR DESCRIPTION
Fixing the issue where the chef environement has no nodes in it, it keeps waiting for the chef runs to complete for the wait time specified.