### PR TITLE
Add import of Task.Common module

### DIFF
--- a/Tasks/AzureCloudPowerShellDeployment/Publish-AzureCloudDeployment.ps1
+++ b/Tasks/AzureCloudPowerShellDeployment/Publish-AzureCloudDeployment.ps1
@@ -165,6 +165,8 @@ function Get-DiagnosticsExtensions($storageAccount, $extensionsPath)
 
 Write-Host "Entering script Publish-AzureCloudDeployment.ps1"
 
+import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
+
 Write-Host "ConnectedServiceName= $ConnectedServiceName "
 Write-Host "ServiceName= $ServiceName"
 Write-Host "ServiceLocation= $ServiceLocation"

--- a/Tasks/AzureCloudPowerShellDeployment/task.json
+++ b/Tasks/AzureCloudPowerShellDeployment/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 9
+    "Patch": 10
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureCloudPowerShellDeployment/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeployment/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 9
+    "Patch": 10
   },
   "demands": [
     "azureps"


### PR DESCRIPTION
In Win10 PowerShell update, Convert-String exists in
Microsoft.PowerShell.Utility so we need to bring this module in (not
sure why it wasn't already being imported).  #308846