### PR TITLE
Adding retry in deletion of chef repo

### DIFF
--- a/Tasks/Chef/Chef.ps1
+++ b/Tasks/Chef/Chef.ps1
@@ -191,7 +191,13 @@ finally
     if ([string]::IsNullOrEmpty($global:chefRepo) -eq $false)
     {
         Write-Verbose "Deleting Chef Repo" -verbose
-        Remove-Item -Recurse -Force $global:chefRepo
+        #adding this as knife sometimes takes hold of the repo for a little time before deleting
+        $deleteChefRepoScript = 
+        { 
+            Remove-Item -Recurse -Force $global:chefRepo 
+        }
+
+        Invoke-WithRetry -Command $deleteChefRepoScript -RetryDelay 10 -MaxRetries 10 -OperationDetail "deleting chef repo"
         Write-Verbose "Chef Repo Deleted" -verbose
     }
 }


### PR DESCRIPTION
- This is needed as in very very rare case, knife command sometimes takes hold of the chef repo, for a little time after it completes execution(that only when there is a retry in knife runs list). Adding it just in case to improve reliability.