### PR TITLE
Supplying UnRegister TestAgent script in case of failure scenarios

### DIFF
--- a/Tasks/DeployTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployTestAgent/TestAgentConfiguration.ps1
@@ -297,9 +297,9 @@ function LoadDependentDlls
 
 	$vsRoot = Locate-TestVersionAndVsRoot($TestAgentVersion)
 	$assemblylist = 
-				 (Join-Path -Path $vsRoot  -ChildPath "PrivateAssemblies\TestAgent\Microsoft.TeamFoundation.Client.dll").ToString(),
-				 (Join-Path -Path $vsRoot  -ChildPath "PrivateAssemblies\TestAgent\Microsoft.TeamFoundation.Common.dll").ToString(),
-				 (Join-Path -Path $vsRoot  -ChildPath "PrivateAssemblies\TestAgent\Microsoft.VisualStudio.Services.Common.dll").ToString(),
+				 (Join-Path -Path $vsRoot  -ChildPath "TestAgent\Microsoft.TeamFoundation.Client.dll").ToString(),
+				 (Join-Path -Path $vsRoot  -ChildPath "TestAgent\Microsoft.TeamFoundation.Common.dll").ToString(),
+				 (Join-Path -Path $vsRoot  -ChildPath "TestAgent\Microsoft.VisualStudio.Services.Common.dll").ToString(),
 				 (Join-Path -Path $vsRoot  -ChildPath "PrivateAssemblies\Microsoft.VisualStudio.TestService.Common.dll").ToString()
 
 	foreach ($asm in $assemblylist)

--- a/Tasks/RunDistributedTests/RunDistributedTests.ps1
+++ b/Tasks/RunDistributedTests/RunDistributedTests.ps1
@@ -27,10 +27,15 @@ Write-Verbose "TestConfiguration = $testConfigurations"
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.DistributedTestAutomation"
 
+# Get current directory.
+$currentDirectory = Convert-Path .
+$unregisterTestAgentLocation = Join-Path -Path $currentDirectory -ChildPath "TestAgentUnRegistration.ps1"
+Write-Verbose "UnregisterTestAgent script Path  = $unRegisterTestAgentLocation"
+
 Write-Verbose "Getting the connection object"
 $connection = Get-VssConnection -TaskContext $distributedTaskContext
 
 Write-Verbose "Calling Invoke-RunDistributedTests"
-Invoke-RunDistributedTests -EnvironmentName $environment -SourceFilter $sourcefilters -TestCaseFilter $testFilterCriteria -RunSettingsPath $runSettingsFile -Platform $platform -Configuration $configuration -CodeCoverageEnabled $codeCoverageEnabled -TestRunParams $overrideRunParams -TestDropLocation $dropLocation -Connection $connection -TestConfiguration $testConfigurations
+Invoke-RunDistributedTests -EnvironmentName $environment -SourceFilter $sourcefilters -TestCaseFilter $testFilterCriteria -RunSettingsPath $runSettingsFile -Platform $platform -Configuration $configuration -CodeCoverageEnabled $codeCoverageEnabled -TestRunParams $overrideRunParams -TestDropLocation $dropLocation -Connection $connection -TestConfiguration $testConfigurations -UnregisterAgentLocation $unregisterTestAgentLocation
 
 Write-Verbose "Leaving script RunDistributedTests.ps1"

--- a/Tasks/RunDistributedTests/TestAgentUnRegistration.ps1
+++ b/Tasks/RunDistributedTests/TestAgentUnRegistration.ps1
@@ -1,0 +1,152 @@
+﻿function Locate-TestVersionAndVsRoot([string] $Version)
+{
+    if ([string]::IsNullOrWhiteSpace($Version))
+    {
+        #Find the latest version
+        $regPath = "HKLM:\SOFTWARE\Microsoft\DevDiv\vstf\Servicing"
+        if (-not (Test-Path $regPath))
+        {
+            $regPath = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\DevDiv\vstf\Servicing"
+        }
+        $Version = Get-Item $regPath | %{$_.GetSubKeyNames()} | Sort-Object -Descending | Select-Object -First 1
+        if ([string]::IsNullOrWhiteSpace($Version))
+        {
+            return $null
+        }
+    }
+
+    # Lookup the install location
+    $installRegPath = ("SOFTWARE\Microsoft\VisualStudio\{0}\EnterpriseTools\QualityTools" -f $Version)
+
+    $installRoot = Get-RegistryValueIgnoreError CurrentUser "$installRegPath" "InstallDir" Registry32
+    if (-not $installRoot)
+    {
+        $installRoot = Get-RegistryValueIgnoreError CurrentUser "$installRegPath" "InstallDir" Registry64
+    }
+
+    if (-not $installRoot)
+    {
+        $installRoot = Get-RegistryValueIgnoreError LocalMachine "$installRegPath" "InstallDir" Registry32
+        if (-not $installRoot)
+        {
+            $installRoot = Get-RegistryValueIgnoreError LocalMachine "$installRegPath" "InstallDir" Registry64
+        }
+    }
+
+    if (-not $installRoot)
+    {
+        # We still got nothing
+        throw "Unable to find TestAgent installation path"
+    }
+    return $installRoot
+}
+
+function Get-RegistryValueIgnoreError
+{
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [Microsoft.Win32.RegistryHive]
+        $RegistryHive,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $Key,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $Value,
+
+        [parameter(Mandatory = $true)]
+        [Microsoft.Win32.RegistryView]
+        $RegistryView
+    )
+
+    try
+    {
+        $baseKey = [Microsoft.Win32.RegistryKey]::OpenBaseKey($RegistryHive, $RegistryView)
+        $subKey =  $baseKey.OpenSubKey($Key)
+        if($subKey -ne $null)
+        {
+            return $subKey.GetValue($Value)
+        }
+    }
+    catch
+    {
+        #ignore
+    }
+    return $null
+}
+
+function InvokeTestAgentConfigExe([string[]] $Arguments, [string] $Version)
+{
+    $ExeName = "TestAgentConfig.exe"
+    if (-not (Test-IsAdmin))
+    {
+        throw "You need to be an Administrator to run this tool."
+    }
+
+    $vsRoot = Locate-TestVersionAndVsRoot($Version)
+    if ([string]::IsNullOrWhiteSpace($vsRoot))
+    {
+        throw "Could not locate TestAgent installation directory for `$Version=$Version. Ensure that TestAgent is installed."
+    }
+
+    $exePath = Join-Path -Path $vsRoot -ChildPath $ExeName
+    if (Test-Path $exePath)
+    {
+        $pinfo = New-Object System.Diagnostics.ProcessStartInfo
+        $pinfo.FileName = $exePath
+        $pinfo.RedirectStandardError = $true
+        $pinfo.RedirectStandardOutput = $true
+        $pinfo.UseShellExecute = $false
+        $pinfo.Arguments = $Arguments
+
+        $p = New-Object System.Diagnostics.Process
+        $p.StartInfo = $pinfo
+
+        $p.Start() | Out-Null
+        $p.WaitForExit()
+
+        $stdout = $p.StandardOutput.ReadToEnd()
+        $stderr = $p.StandardError.ReadToEnd()
+
+        Write-Verbose -Message ("Stdout : {0}" -f $stdout) -Verbose
+        Write-Warning -Message ("Stderr : {0}" -f $stderr)
+        Write-Verbose -Message ("Exit code : {0}" -f $p.ExitCode) -Verbose
+
+        $out = @{
+                    ExitCode = $p.ExitCode
+                    CommandOutput = $stdout
+                }
+					
+        return $out
+    }
+
+    throw "Did not find TestAgentConfig.exe at : $exePath. Ensure that TestAgent is installed."
+}
+
+
+function TestAgent-UnRegsiter
+{
+ param
+    (
+        [String] $TestAgentVersion 
+    )
+
+
+    Write-Verbose -Message "Trying to delete TestAgent configurations." -verbose
+
+    $configOut = InvokeTestAgentConfigExe -Arguments @( "Delete" ) -Version $TestAgentVersion         
+    return $configOut.ExitCode
+}
+
+function Test-IsAdmin
+{
+    $wid = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $prp = New-Object System.Security.Principal.WindowsPrincipal($wid)
+    $adm = [System.Security.Principal.WindowsBuiltInRole]::Administrator
+    return $prp.IsInRole($adm)
+}
+
+$output = TestAgent-UnRegsiter -TestAgentVersion $TestAgentVersion

--- a/Tasks/RunDistributedTests/task.json
+++ b/Tasks/RunDistributedTests/task.json
@@ -16,6 +16,7 @@
     },
     "demands": [
     ],
+    "minimumAgentVersion": "1.83.0",
     "groups": [
         {
             "name": "testEnvironment",

--- a/Tasks/RunDistributedTests/task.loc.json
+++ b/Tasks/RunDistributedTests/task.loc.json
@@ -18,6 +18,7 @@
     "Patch": 1
   },
   "demands": [],
+  "minimumAgentVersion": "1.83.0",
   "groups": [
     {
       "name": "testEnvironment",


### PR DESCRIPTION
1. Supplying UnRegisterAgent script along with run tests, it will be used to unregister agent in negative scenarios
2. fixing file path for dependent modules
3. enabled min release for agent 

Note: Testing for E2E is underway.