### PR TITLE
Users/achalla/reboot fix m83

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/TestAgentInstall.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentInstall.ps1
@@ -12,14 +12,18 @@ function Install-Product($SetupPath, $UserName, $Password, $ProductVersion, $Arg
         if($versionToInstall -ne $null)
         {
 		$versionToInstall = $versionToInstall.split('.')
+                $versionToInstall[3] = $null
+                $versionToInstall = -join $versionToInstall
         }
 
         if($versionInstalled -ne $null)
         {
 		$versionInstalled = $versionInstalled.split('.')
+                $versionInstalled[3] = $null
+                $versionInstalled = -join $versionInstalled
         }
         
-	if(($isProductExists -eq $InstalledCheckRegValueData) -and ($versionToInstall -ne $null) -and ($versionInstalled -ne $null) -and ($versionToInstall[0] -le $versionInstalled[0]) -and ($versionToInstall[1] -le $versionInstalled[1]) -and ($versionToInstall[2] -le $versionInstalled[2]))
+	if(($isProductExists -eq $InstalledCheckRegValueData) -and ($versionToInstall -ne $null) -and ($versionInstalled -ne $null) -and ($versionToInstall -le $versionInstalled))
 	{
 		Write-Verbose -Message ("Test Agent already exists") -verbose
 	}

--- a/Tasks/DeployVisualStudioTestAgent/TestAgentInstall.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentInstall.ps1
@@ -6,6 +6,7 @@ function Install-Product($SetupPath, $UserName, $Password, $ProductVersion, $Arg
                 
 	$isProductExists = Get-ProductEntry -InstalledCheckRegKey $InstalledCheckRegKey -InstalledCheckRegValueName $InstalledCheckRegValueName         
 
+        $versionToInstall = ((Get-Item $SetupPath).VersionInfo.FileVersion) 
         $versionInstalled = (Get-ProductEntry -InstalledCheckRegKey $InstalledCheckRegKey -InstalledCheckRegValueName "version")
 
         if($versionToInstall -ne $null)

--- a/Tasks/DeployVisualStudioTestAgent/TestAgentInstall.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentInstall.ps1
@@ -3,13 +3,23 @@ function Install-Product($SetupPath, $UserName, $Password, $ProductVersion, $Arg
 	$InstalledCheckRegKey = ("SOFTWARE\Microsoft\DevDiv\vstf\Servicing\{0}\testagentcore" -f $ProductVersion)
 	$InstalledCheckRegValueName = "Install"
 	$InstalledCheckRegValueData = "1"
+                
+	$isProductExists = Get-ProductEntry -InstalledCheckRegKey $InstalledCheckRegKey -InstalledCheckRegValueName $InstalledCheckRegValueName         
 
-	$isProductExists = Get-ProductEntry -InstalledCheckRegKey $InstalledCheckRegKey -InstalledCheckRegValueName $InstalledCheckRegValueName -InstalledCheckRegValueData $InstalledCheckRegValueData
-        $testAgentFileExists = Test-Path "$env:SystemDrive\TestAgent\testagent"
+        $versionInstalled = (Get-ProductEntry -InstalledCheckRegKey $InstalledCheckRegKey -InstalledCheckRegValueName "version")
 
-	if($testAgentFileExists -and $isProductExists)
+        if($versionToInstall -ne $null)
+        {
+		$versionToInstall = $versionToInstall.split('.')
+        }
+
+        if($versionInstalled -ne $null)
+        {
+		$versionInstalled = $versionInstalled.split('.')
+        }
+        
+	if(($isProductExists -eq $InstalledCheckRegValueData) -and ($versionToInstall -ne $null) -and ($versionInstalled -ne $null) -and ($versionToInstall[0] -le $versionInstalled[0]) -and ($versionToInstall[1] -le $versionInstalled[1]) -and ($versionToInstall[2] -le $versionInstalled[2]))
 	{
-	    # Bug 266057 remove the logic of testagent file creation. Remove the if check, always install testagent.
 		Write-Verbose -Message ("Test Agent already exists") -verbose
 	}
 	else
@@ -47,13 +57,11 @@ function Install-Product($SetupPath, $UserName, $Password, $ProductVersion, $Arg
 		}
 
 		# Verify the TA registry entry
-		$isProductExists = Get-ProductEntry -InstalledCheckRegKey $InstalledCheckRegKey -InstalledCheckRegValueName $InstalledCheckRegValueName -InstalledCheckRegValueData $InstalledCheckRegValueData
+		$isProductExists = Get-ProductEntry -InstalledCheckRegKey $InstalledCheckRegKey -InstalledCheckRegValueName $InstalledCheckRegValueName
 
-		if($isProductExists)
+		if($isProductExists -eq $InstalledCheckRegValueData)
 		{
-			Write-Verbose "Test Agent installed successfully" -Verbose
-                        #creating testagent file to indicate testagent installed successfully
-             		New-Item -Path "$env:SystemDrive\TestAgent\testagent" -type File
+			Write-Verbose "Test Agent installed successfully" -Verbose                        
    		}
 		else
 		{
@@ -105,14 +113,13 @@ function Get-ProductEntry {
 	param
 	(
 		[string] $InstalledCheckRegKey,
-		[string] $InstalledCheckRegValueName,
-		[string] $InstalledCheckRegValueData
+		[string] $InstalledCheckRegValueName
 	)
+
+        $installValue = $null
 
 	if ($InstalledCheckRegKey -and $InstalledCheckRegValueName -and $InstalledCheckRegValueData)
 	{
-		$installValue = $null
-
 		#if 64bit OS, check 64bit registry view first
 		if ((Get-WmiObject -Class Win32_OperatingSystem -ComputerName "localhost" -ea 0).OSArchitecture -eq '64-bit')
 		{
@@ -123,17 +130,9 @@ function Get-ProductEntry {
 		{
 			$installValue = Get-RegistryValue -RegistryHive LocalMachine -Key $InstalledCheckRegKey -Value $InstalledCheckRegValueName -RegistryView Registry32
 		}
-
-		if($installValue)
-		{
-			if($InstalledCheckRegValueData -and $installValue -eq $InstalledCheckRegValueData)
-			{
-				return $true
-			}
-		}
 	}
 
-	return $false
+	return $installValue
 }
 
 Install-Product -SetupPath $setupPath -UserName $userName -Password $password -ProductVersion "14.0" -Arguments "/Quiet /NoRestart"

--- a/Tasks/DeployVisualStudioTestAgent/TestAgentInstall.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentInstall.ps1
@@ -12,14 +12,20 @@ function Install-Product($SetupPath, $UserName, $Password, $ProductVersion, $Arg
         if($versionToInstall -ne $null)
         {
 		$versionToInstall = $versionToInstall.split('.')
-                $versionToInstall[3] = $null
+                if($versionToInstall.length -gt 3)
+                {
+                	$versionToInstall[3] = $null
+		}
                 $versionToInstall = -join $versionToInstall
         }
 
         if($versionInstalled -ne $null)
         {
 		$versionInstalled = $versionInstalled.split('.')
-                $versionInstalled[3] = $null
+		if($versionInstalled.length -gt 3)
+		{
+                	$versionInstalled[3] = $null
+		}
                 $versionInstalled = -join $versionInstalled
         }
         


### PR DESCRIPTION
related bug : Bug 320689:even if agent version is same what is installed on machine, it installs and restarts machine.

Avoid installing testagent whenever existing testagent is higher or equal version as of the desired testagent

Testing done: manual validation of all possible cases.