### PR TITLE
Renaming Get-Variable cmdlet to Get-TaskVariable

### DIFF
--- a/Tasks/Gulp/Gulptask.ps1
+++ b/Tasks/Gulp/Gulptask.ps1
@@ -15,7 +15,7 @@ $gulp = Get-Command -Name gulp -ErrorAction Ignore
 if(!$gulp)
 {
     Write-Verbose "try to find gulp in the node_modules in the sources directory"
-    $buildSourcesDirectory = Get-Variable -Context $distributedTaskContext -Name "Build.SourcesDirectory"
+    $buildSourcesDirectory = Get-TaskVariable -Context $distributedTaskContext -Name "Build.SourcesDirectory"
     $nodeBinPath = Join-Path -Path $buildSourcesDirectory -ChildPath 'node_modules\.bin'
 
     if(Test-Path -Path $nodeBinPath -PathType Container)

--- a/Tasks/Gulp/task.json
+++ b/Tasks/Gulp/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 0,
         "Minor": 5,
-        "Patch": 1
+        "Patch": 2
     },
     "demands" : [
         "gulp"

--- a/Tasks/Gulp/task.loc.json
+++ b/Tasks/Gulp/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 0,
     "Minor": 5,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "gulp"

--- a/Tasks/PublishBuildArtifacts/PublishBuildArtifacts.ps1
+++ b/Tasks/PublishBuildArtifacts/PublishBuildArtifacts.ps1
@@ -26,9 +26,9 @@ Write-Host "ArtifactType = $ArtifactType"
 # Import the Task.Internal dll that has all the cmdlets we need for Build
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Internal"
 
-$buildId = Get-Variable $distributedTaskContext "build.buildId"
-$teamProjectId = Get-Variable $distributedTaskContext "system.teamProjectId"
-$stagingFolder = Get-Variable $distributedTaskContext "build.artifactstagingdirectory"
+$buildId = Get-TaskVariable $distributedTaskContext "build.buildId"
+$teamProjectId = Get-TaskVariable $distributedTaskContext "system.teamProjectId"
+$stagingFolder = Get-TaskVariable $distributedTaskContext "build.artifactstagingdirectory"
 
 # gather files into staging folder
 Write-Host "Preparing artifact content in staging folder $stagingFolder..."

--- a/Tasks/PublishBuildArtifacts/task.json
+++ b/Tasks/PublishBuildArtifacts/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
   ],

--- a/Tasks/PublishBuildArtifacts/task.loc.json
+++ b/Tasks/PublishBuildArtifacts/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "1.83.0",

--- a/Tasks/VsTest/VSTest.ps1
+++ b/Tasks/VsTest/VSTest.ps1
@@ -50,7 +50,7 @@ if($testAssemblyFiles)
         $vsTestVersion = $null
     }
 
-    $artifactsDirectory = Get-Variable -Context $distributedTaskContext -Name "System.ArtifactsDirectory" -Global $FALSE
+    $artifactsDirectory = Get-TaskVariable -Context $distributedTaskContext -Name "System.ArtifactsDirectory" -Global $FALSE
 
     $workingDirectory = $artifactsDirectory
     $testResultsDirectory = $workingDirectory + "\" + "TestResults"

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 15
+    "Patch": 16
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 15
+    "Patch": 16
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
Due to a naming conflict with our Get-Variable (PowerShell also has one)
that caused the Azure script deployment task to fail in M83, we need to
rename the Get-Variable cmdlet to Get-TaskVariable.