### PR TITLE
Remove preview feature flags from BDT tasks

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -6,7 +6,6 @@
     "helpMarkDown": "Deploy and configure Test Agent to run tests on a lab machine group",
     "category": "Test",
     "visibility": [
-                "Preview",
                 "Build"
                   ],
     "author": "Microsoft Corporation",

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -9,7 +9,6 @@
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Test",
   "visibility": [
-    "Preview",
     "Build"
   ],
   "author": "Microsoft Corporation",

--- a/Tasks/PowerShellOnTargetMachines/task.json
+++ b/Tasks/PowerShellOnTargetMachines/task.json
@@ -6,7 +6,6 @@
     "helpMarkDown": "Execute PowerShell scripts on remote machine(s)",
     "category": "Deploy",
     "visibility": [
-                "Preview",
                 "Build",
                 "Release"
                   ],

--- a/Tasks/PowerShellOnTargetMachines/task.loc.json
+++ b/Tasks/PowerShellOnTargetMachines/task.loc.json
@@ -9,7 +9,6 @@
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Deploy",
   "visibility": [
-    "Preview",
     "Build",
     "Release"
   ],

--- a/Tasks/RunDistributedTests/task.json
+++ b/Tasks/RunDistributedTests/task.json
@@ -6,7 +6,6 @@
     "helpMarkDown": "Run tests distributedly using multiple test agents on a lab machine group",
     "category": "Test",
     "visibility": [
-                    "Preview",
                     "Build"
                   ],
     "author": "Microsoft Corporation",

--- a/Tasks/RunDistributedTests/task.loc.json
+++ b/Tasks/RunDistributedTests/task.loc.json
@@ -9,7 +9,6 @@
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Test",
   "visibility": [
-    "Preview",
     "Build"
   ],
   "author": "Microsoft Corporation",

--- a/Tasks/WindowsMachineFileCopy/task.json
+++ b/Tasks/WindowsMachineFileCopy/task.json
@@ -6,7 +6,6 @@
     "helpMarkDown": "Copy files to remote machine(s)",
     "category": "Deploy",
     "visibility": [
-                "Preview",
                 "Build",
                 "Release"
                   ],

--- a/Tasks/WindowsMachineFileCopy/task.loc.json
+++ b/Tasks/WindowsMachineFileCopy/task.loc.json
@@ -9,7 +9,6 @@
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Deploy",
   "visibility": [
-    "Preview",
     "Build",
     "Release"
   ],


### PR DESCRIPTION
Changes : Removed preview feature flags from the 4 BDT tasks.
Testing Done :
Manual : Without preview featureflags, our tasks are being visible, ensured that I can add them to a build defn. and save.
Automation : None.