### PR TITLE
bug fix

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
@@ -343,7 +343,7 @@ function ReadCredentials
     [String] $TestAgentVersion
     )
 	
-    LoadDependentDlls($TestAgentVersion)    
+    LoadDependentDlls($TestAgentVersion) | Out-Null   
     $creds = [Microsoft.VisualStudio.TestService.Common.CredentialStoreHelper]::GetStoredCredential($TFSCollectionUrl)       
   
     return $creds                    


### PR DESCRIPTION
Powershell function returns object[] instead of object when there are some messages for echo . redirecting the output of loading dlls to null to change the behavior of the return of function.

Testing : bdt in all os