### PR TITLE
Bug 329449:Testagent configuration doesnt restart machine though "configure as process is selected" intermittently

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
@@ -628,7 +628,7 @@ function ConfigureTestAgent
         [System.Management.Automation.PSCredential] $AgentUserCredential
     )
 
-    EnableTracing -TestAgentVersion $TestAgentVersion
+    EnableTracing -TestAgentVersion $TestAgentVersion | Out-Null
 
     $ret = -1
     if ($AsServiceOrProcess -eq "Service")


### PR DESCRIPTION
issue : Testagent configuration returns some message along with return type. This happens only for the first time configuration. From second time , these message is not appended.

Testing: Tested on all os.