### PR TITLE
Updated pathtoCustomTestAdapters type to filePath

### DIFF
--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -100,7 +100,7 @@
     },
     {
       "name": "pathtoCustomTestAdapters",
-      "type": "string",
+      "type": "filePath",
       "label": "Path to Custom Test Adapters",
       "defaultValue": "",
       "required": false,


### PR DESCRIPTION
This field determines how the Build.vNext runtime treats the user entered value when passing it to a PowerShell script.  As a string, it is passed through unchanged.  As a filePath, Build.vNext corrects relative paths to be absolute paths in your solution directory.  

Thus, when entering a relative path (as is often common, ex. when the adapters are added as nuget packages, i.e. XUnit), as a String, it operates relative to the location of the PowerShell script! This is nowhere near where your solution files are stored, and so it can't find your custom test adapters.  

However, a field with type filePath gets the solution directory prepended to it first (if it's a relative path).  Thus, it is possible to specify relative paths and have them look in the solution directory, rather than deep in the TFS internals.