### PR TITLE
Bug 333113:Failed to start DTAAgentExecutionService on Azure VM

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
@@ -438,7 +438,19 @@ function CanSkipTestAgentConfiguration
 
     if ($PSBoundParameters.ContainsKey('AgentUserCredential'))
     {
-        if ($AgentUserCredential.UserName -ne $existingConfiguration.UserName)
+        if ($AgentUserCredential.UserName -like ".\*" -or ( -not ($AgentUserCredential.UserName.Contains("\")) ) )
+        {
+            # for azure machines user name is either like .\username or username   
+            $existingUserName = $existingConfiguration.UserName.split('\')
+            $requiredUserName = $AgentUserCredential.UserName.split('\')
+           
+            if($existingUserName[$existingUserName.Length -1] -ne $requiredUserName[$requiredUserName.Length -1])
+            {
+ 	       Write-Verbose -Message ("UserName mismatch. Expected : {0}, Current {1}. Reconfiguration required." -f $existingUserName[$existingUserName.Length -1], $requiredUserName[$requiredUserName.Length -1]) -Verbose
+                return $false
+            }
+        }
+        elseif ($AgentUserCredential.UserName -ne $existingConfiguration.UserName)
         {
             Write-Verbose -Message ("UserName mismatch. Expected : {0}, Current {1}. Reconfiguration required." -f $AgentUserCredential.UserName, $existingConfiguration.UserName) -Verbose
             return $false

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
 

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [],
   "minimumAgentVersion": "1.83.0",


### PR DESCRIPTION
If machine group is configured with a local user, DtaExecutiohost is launched with user machinename/username. 
In the deploy task user can pass either ./username or username for username field. (As there will be multiple machines in the environment, user cannot pass machinename\username here)

In our task we check if the username passed in the task and user with which process configured matches. If not we configure again. Because of this machine goes to loop of restart.

Fix : match username appropriately