### PR TITLE
Clarify Azure Web Deployment as Visual Studio-only

### DIFF
--- a/Tasks/AzureWebPowerShellDeployment/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureWebPowerShellDeployment/Strings/resources.resjson/en-US/resources.resjson
@@ -2,18 +2,18 @@
 // GENERATED FILE - DO NOT EDIT DIRECTLY
 // *******************************************************
 {
-  "loc.friendlyName": "Azure Web Site Deployment",
+  "loc.friendlyName": "Azure Web App Deployment",
   "loc.helpMarkDown": "[More Information](http://go.microsoft.com/fwlink/?LinkID=613750)",
-  "loc.description": "Deploy a website to Microsoft Azure",
+  "loc.description": "Publish a Visual Studio web project to a Microsoft Azure Web App using Web Deploy",
   "loc.instanceNameFormat": "Azure Deployment: $(WebSiteName)",
   "loc.input.label.ConnectedServiceName": "Azure Subscription",
   "loc.input.help.ConnectedServiceName": "Azure subscription to target for deployment.",
-  "loc.input.label.WebSiteName": "Web Site Name",
-  "loc.input.label.WebSiteLocation": "Web Site Location",
+  "loc.input.label.WebSiteName": "Web App Name",
+  "loc.input.label.WebSiteLocation": "Web App Location",
   "loc.input.help.WebSiteLocation": "Select a region for deployment.",
   "loc.input.label.Slot": "Slot",
   "loc.input.help.Slot": "Slot",
-  "loc.input.label.Package": "Package",
-  "loc.input.help.Package": "Path of package under the default artifact directory.",
+  "loc.input.label.Package": "Web Deploy Package",
+  "loc.input.help.Package": "Path to the Visual Studio Web Deploy package under the default artifact directory.",
   "loc.input.label.AdditionalArguments": "Additional Arguments"
 }

--- a/Tasks/AzureWebPowerShellDeployment/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureWebPowerShellDeployment/Strings/resources.resjson/en-US/resources.resjson
@@ -4,7 +4,7 @@
 {
   "loc.friendlyName": "Azure Web App Deployment",
   "loc.helpMarkDown": "[More Information](http://go.microsoft.com/fwlink/?LinkID=613750)",
-  "loc.description": "Publish a Visual Studio web project to a Microsoft Azure Web App using Web Deploy",
+  "loc.description": "Publish a Visual Studio Web project to a Microsoft Azure Web App using Web Deploy",
   "loc.instanceNameFormat": "Azure Deployment: $(WebSiteName)",
   "loc.input.label.ConnectedServiceName": "Azure Subscription",
   "loc.input.help.ConnectedServiceName": "Azure subscription to target for deployment.",

--- a/Tasks/AzureWebPowerShellDeployment/task.json
+++ b/Tasks/AzureWebPowerShellDeployment/task.json
@@ -2,7 +2,7 @@
   "id": "DCBEF2C9-E4F4-4929-82B2-EA7FC9166109",
   "name": "AzureWebPowerShellDeployment",
   "friendlyName": "Azure Web App Deployment",
-  "description": "Publish a Visual Studio web project to a Microsoft Azure Web App using Web Deploy",
+  "description": "Publish a Visual Studio Web project to a Microsoft Azure Web App using Web Deploy",
   "helpMarkDown": "[More Information](http://go.microsoft.com/fwlink/?LinkID=613750)",
   "category": "Deploy",
   "visibility": [

--- a/Tasks/AzureWebPowerShellDeployment/task.json
+++ b/Tasks/AzureWebPowerShellDeployment/task.json
@@ -1,8 +1,8 @@
 ﻿{
   "id": "DCBEF2C9-E4F4-4929-82B2-EA7FC9166109",
   "name": "AzureWebPowerShellDeployment",
-  "friendlyName": "Azure Web Site Deployment",
-  "description": "Deploy a website to Microsoft Azure",
+  "friendlyName": "Azure Web App Deployment",
+  "description": "Publish a Visual Studio web project to a Microsoft Azure Web App using Web Deploy",
   "helpMarkDown": "[More Information](http://go.microsoft.com/fwlink/?LinkID=613750)",
   "category": "Deploy",
   "visibility": [
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 14
+    "Patch": 15
   },
   "demands": [
     "azureps"
@@ -31,14 +31,14 @@
     {
       "name": "WebSiteName",
       "type": "pickList",
-      "label": "Web Site Name",
+      "label": "Web App Name",
       "defaultValue": "",
       "required": true
     },
     {
       "name": "WebSiteLocation",
       "type": "pickList",
-      "label": "Web Site Location",
+      "label": "Web App Location",
       "defaultValue": "South Central US",
       "required": true,
       "helpMarkDown": "Select a region for deployment.",
@@ -72,9 +72,9 @@
     {
       "name": "Package",
       "type": "string",
-      "label": "Package",
+      "label": "Web Deploy Package",
       "defaultValue": "",
-      "helpMarkDown": "Path of package under the default artifact directory.",
+      "helpMarkDown": "Path to the Visual Studio Web Deploy package under the default artifact directory.",
       "required": true
     },
     {

--- a/Tasks/AzureWebPowerShellDeployment/task.loc.json
+++ b/Tasks/AzureWebPowerShellDeployment/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 14
+    "Patch": 15
   },
   "demands": [
     "azureps"


### PR DESCRIPTION
The **Azure Web Site Deployment** task can be misleading for Java users.  It only supports deployment of a Web Deploy package generated by Visual Studio ([see further](https://msdn.microsoft.com/en-us/library/azure/dn722468.aspx)).  It doesn't support other deployments, including Java apps.  In addition, Azure has renamed "Web Sites" to "Web Apps."  This pull request seeks to clarify the capabilities of this task.