### PR TITLE
Fix for Bug Agent fails to register when project collection or projec…

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
@@ -196,14 +196,14 @@ function Set-TestAgentConfiguration
 
     if ($PSBoundParameters.ContainsKey('AgentUserCredential') -and $AgentUserCredential)
     {
-        $configArgs = $configArgs + ("/userName:{0}" -f $AgentUserCredential.UserName)
-        $configArgs = $configArgs + ("/password:{0}" -f $AgentUserCredential.GetNetworkCredential().Password)
+        $configArgs = $configArgs + ("/userName:`"{0}`"" -f $AgentUserCredential.UserName)
+        $configArgs = $configArgs + ("/password:`"{0}`"" -f $AgentUserCredential.GetNetworkCredential().Password)
     }
 
     if ($PSBoundParameters.ContainsKey('MachineUserCredential') -and $MachineUserCredential)
     {
-        $configArgs = $configArgs + ("/adminUserName:{0}" -f $MachineUserCredential.UserName)
-        $configArgs = $configArgs + ("/adminPassword:{0}" -f $MachineUserCredential.GetNetworkCredential().Password)
+        $configArgs = $configArgs + ("/adminUserName:`"{0}`"" -f $MachineUserCredential.UserName)
+        $configArgs = $configArgs + ("/adminPassword:`"{0}`"" -f $MachineUserCredential.GetNetworkCredential().Password)
     }
 
     if ($PSBoundParameters.ContainsKey('EnableAutoLogon'))
@@ -228,7 +228,7 @@ function Set-TestAgentConfiguration
     
     if (-not [string]::IsNullOrWhiteSpace($EnvironmentUrl))
     {
-        $configArgs = $configArgs +  ("/dtlEnvUrl:{0}" -f $EnvironmentUrl)
+        $configArgs = $configArgs +  ("/dtlEnvUrl:`"{0}`"" -f $EnvironmentUrl)
     }
 
     if (-not [string]::IsNullOrWhiteSpace($PersonalAccessToken))
@@ -238,7 +238,7 @@ function Set-TestAgentConfiguration
 
     if (-not [string]::IsNullOrWhiteSpace($MachineName))
     {
-        $configArgs = $configArgs +  ("/dtlMachineName:{0}" -f $MachineName)
+        $configArgs = $configArgs +  ("/dtlMachineName:`"{0}`"" -f $MachineName)
     }
 	if (-not [string]::IsNullOrWhiteSpace($Capabilities))
     {

--- a/Tasks/RunLoadTest/Start-CloudLoadTest.ps1
+++ b/Tasks/RunLoadTest/Start-CloudLoadTest.ps1
@@ -194,7 +194,7 @@ function UploadTestDrop($testdrop, $src)
     Write-Verbose "Calling AzCopy = $azcopy" -Verbose
 
     $azlog = ("{0}\..\azlog" -f $src)
-    $args = ("/Source:{0} /Dest:{1} /DestSAS:{2} /S /Z:{3}" -f $src, $dest, $sas, $azlog)
+    $args = ("/Source:`"{0}`" /Dest:{1} /DestSAS:{2} /S /Z:`"{3}`"" -f $src, $dest, $sas, $azlog)
     Write-Verbose "AzCopy Args = $args" -Verbose
 
     Invoke-Tool -Path $azcopy -Arguments $args


### PR DESCRIPTION
…t name has a space.

Automated test run scenarios (DTA and CLT) were not working when project
name or collection had a space. We need to pass the parameters
appropriately quoted to the process from our power shell scripts