### PR TITLE
Bug 363595:Configuring Agent with Interactive process is failing in HTTPS

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 5
     },
     "demands": [
 

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 4
+    "Patch": 5
   },
   "demands": [],
   "minimumAgentVersion": "1.85.0",


### PR DESCRIPTION
Bug 363595:Configuring Agent with Interactive process is failing in HTTPS

1. Getting details of WinRm configuration on the machine
2. Making sure we are using correct parameters while launching new PSSession for DTAExecutionHost