### PR TITLE
Import the module containing the powershell Get-LocalizedString cmdlet

### DIFF
--- a/Tasks/PublishBuildArtifacts/PublishBuildArtifacts.ps1
+++ b/Tasks/PublishBuildArtifacts/PublishBuildArtifacts.ps1
@@ -26,6 +26,7 @@ Write-Verbose "TargetPath = $TargetPath"
 
 # Import the Task.Internal dll that has all the cmdlets we need for Build
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Internal"
+import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
 
 $buildId = Get-TaskVariable $distributedTaskContext "build.buildId"
 $teamProjectId = Get-TaskVariable $distributedTaskContext "system.teamProjectId"


### PR DESCRIPTION
I noticed the following error when running a build that uses the PublishBuildArtifacts task:

'The term 'Get-LocalizedString' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.'

This changeset pulls in the required powershell module that contains it.