### PR TITLE
Allow spaces in the grunt and gulp file paths.

### DIFF
--- a/Tasks/Grunt/Grunttask.ps1
+++ b/Tasks/Grunt/Grunttask.ps1
@@ -38,14 +38,13 @@ if(!$grunt)
     }
 }
 
-
 if($targets)
 {
-    $arguments = $targets + " --gruntfile " + $gruntFile + " " + $arguments    
+    $arguments = $targets + " --gruntfile \"" + $gruntFile + "\" " + $arguments    
 }
 else
 {
-    $arguments = "--gruntFile " + $gruntFile + " " + $arguments
+    $arguments = "--gruntFile \"" + $gruntFile + "\" " + $arguments
 }
 
 if($cwd)

--- a/Tasks/Grunt/Grunttask.ps1
+++ b/Tasks/Grunt/Grunttask.ps1
@@ -38,14 +38,14 @@ if(!$grunt)
     }
 }
 
+$arguments = ""
+
 if($targets)
 {
-    $arguments = $targets + " --gruntfile \"" + $gruntFile + "\" " + $arguments    
+    $arguments += $targets + " "   
 }
-else
-{
-    $arguments = "--gruntFile \"" + $gruntFile + "\" " + $arguments
-}
+
+$arguments += "--gruntfile `"" + $gruntFile + "`" " + $arguments
 
 if($cwd)
 {

--- a/Tasks/Gulp/Gulptask.ps1
+++ b/Tasks/Gulp/Gulptask.ps1
@@ -41,11 +41,11 @@ if(!$gulp)
 
 if($targets)
 {
-    $arguments = $targets + " --gulpfile " + $gulpFile + " " + $arguments    
+    $arguments = $targets + " --gulpfile `"" + $gulpFile + "`" " + $arguments    
 }
 else
 {
-    $arguments = "--gulpfile " + $gulpFile + " " + $arguments
+    $arguments = "--gulpfile `"" + $gulpFile + "`" " + $arguments
 }
 
 if($cwd)

--- a/Tasks/Gulp/Gulptask.ps1
+++ b/Tasks/Gulp/Gulptask.ps1
@@ -38,15 +38,14 @@ if(!$gulp)
     }
 }
 
+$arguments = ""
 
 if($targets)
 {
-    $arguments = $targets + " --gulpfile `"" + $gulpFile + "`" " + $arguments    
+    $arguments += $targets + " "   
 }
-else
-{
-    $arguments = "--gulpfile `"" + $gulpFile + "`" " + $arguments
-}
+
+$arguments += "--gulpfile `"" + $gulpFile + "`" " + $arguments
 
 if($cwd)
 {


### PR DESCRIPTION
If the Git Repository name has spaces in it, the current script breaks. These changes wrap the grunt/gulpfile logic in quotes. Ignore the first commit.... it was an accident.