### PR TITLE
Fix on publishBuildArtifacts task

### DIFF
--- a/Tasks/PublishBuildArtifacts/publishBuildArtifacts.js
+++ b/Tasks/PublishBuildArtifacts/publishBuildArtifacts.js
@@ -155,13 +155,13 @@ else {
             if (artifactType === "container") {
                 data["containerfolder"] = artifactName;
                 data["localpath"] = stagingFolder;
-                tl.command("artifact.upload", data, "Uploading artifact");
+                tl.writeCommand("artifact.upload", data, "Uploading artifact");
             }
             else if (artifactType === "filepath") {
                 tl.mkdirP(targetPath);
                 tl.cp("-Rf", stagingFolder, targetPath);
                 data["artifactlocation"] = targetPath;
-                tl.command("artifact.associate", data, "Associating artifact");
+                tl.writeCommand("artifact.associate", data, "Associating artifact");
             }
         }
         catch (err) {

--- a/Tasks/PublishBuildArtifacts/publishBuildArtifacts.ts
+++ b/Tasks/PublishBuildArtifacts/publishBuildArtifacts.ts
@@ -192,14 +192,14 @@ else {
             if (artifactType === "container") {
                 data["containerfolder"] = artifactName;
                 data["localpath"] = stagingFolder;
-                tl.command("artifact.upload", data, "Uploading artifact");
+                tl.writeCommand("artifact.upload", data, "Uploading artifact");
             }
             else if (artifactType === "filepath") {
                 tl.mkdirP(targetPath);
                 tl.cp("-Rf", stagingFolder, targetPath);
 
                 data["artifactlocation"] = targetPath;
-                tl.command("artifact.associate", data, "Associating artifact");
+                tl.writeCommand("artifact.associate", data, "Associating artifact");
             }
         }
         catch (err) {


### PR DESCRIPTION
Due to refactoring in vsotask.ts (https://github.com/Microsoft/vso-task-lib/blob/ac9584460d19f52b359e6af0cee19c6df9b90606/node/lib/vsotask.ts) the command function was removed and replaced with writeCommand. 

My changes fix the publishbuildartifacts task.