### PR TITLE
Fixes for Invoke command and avoiding reboot

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
@@ -631,16 +631,9 @@ function InvokeDTAExecHostExe([string] $Version, [System.Management.Automation.P
     $exePath = Join-Path -Path $vsRoot -ChildPath $ExeName
     $exePath = "'" + $exePath + "'"
     Try
-    {
-	    $StartDate = New-Object -TypeName DateTime -ArgumentList:(2050,01,01) 
-        $FormatHack = ($([System.Globalization.DateTimeFormatInfo]::CurrentInfo.ShortDatePattern) -replace 'M+/', 'MM/') -replace 'd+/', 'dd/' 
-        $date1 = $StartDate.ToString($FormatHack) 		
-		$sb = 
-		{ 		
-			schtasks.exe /create /TN:DTAConfig /TR:$using:exepath /F /RL:HIGHEST /SD:$using:date1 /SC:ONCE /ST:00:00; Set-Location -Path $using:vsRoot; schtasks.exe /run /TN:DTAConfig ; schtasks.exe /delete /F /TN:DTAConfig
-		}		
-        $session = CreateNewSession -MachineCredential $MachineCredential		
-        Invoke-Command -Session $session -ErrorAction SilentlyContinue -ErrorVariable err -OutVariable out -scriptBlock $sb  -ArgumentList  $exePath, $vsRoot, $date1		
+    {	   		
+		$session = CreateNewSession -MachineCredential $MachineCredential		
+        Invoke-Command -Session $session -ErrorAction SilentlyContinue -ErrorVariable err -OutVariable out -scriptBlock { schtasks.exe /create /TN:DTAConfig /TR:$args /F /RL:HIGHEST /SC:MONTHLY; schtasks.exe /run /TN:DTAConfig ; schtasks.exe /delete /F /TN:DTAConfig }  -ArgumentList $exePath		
         Write-Verbose -Message ("Error : {0} " -f ($err | out-string)) -Verbose
         Write-Verbose -Message ("Output : {0} " -f ($out | out-string)) -Verbose
     }

--- a/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
@@ -637,7 +637,7 @@ function InvokeDTAExecHostExe([string] $Version, [System.Management.Automation.P
         $date1 = $StartDate.ToString($FormatHack)
 
         $session = CreateNewSession -MachineCredential $MachineCredential
-        Invoke-Command -Session $session -ErrorAction Continue -ErrorVariable err -OutVariable out -scriptBlock { schtasks.exe /create /TN:DTAConfig /TR:$args[0] /F /RL:HIGHEST  /SC:ONCE /ST:23:59 ; schtasks.exe /run /TN:DTAConfig;  schtasks.exe /change /disable /TN:DTAConfig } -ArgumentList $exePath
+        Invoke-Command -Session $session -ErrorAction Continue -ErrorVariable err -OutVariable out -scriptBlock { schtasks.exe /create /TN:DTAConfig /TR:$args /F /RL:HIGHEST /SC:MONTHLY; schtasks.exe /run /TN:DTAConfig;  schtasks.exe /change /disable /TN:DTAConfig } -ArgumentList $exePath
 
         Write-Verbose ("Error : {0} " -f ($err | out-string)) -Verbose
         Write-Verbose ("Output : {0} " -f ($out | out-string)) -Verbose

--- a/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
@@ -637,7 +637,7 @@ function InvokeDTAExecHostExe([string] $Version, [System.Management.Automation.P
         $date1 = $StartDate.ToString($FormatHack)
 
         $session = CreateNewSession -MachineCredential $MachineCredential
-        Invoke-Command -Session $session -ErrorAction Continue -ErrorVariable err -OutVariable out -scriptBlock { schtasks.exe /create /TN:DTAConfig /TR:$args /F /RL:HIGHEST /SC:MONTHLY; schtasks.exe /run /TN:DTAConfig;  schtasks.exe /change /disable /TN:DTAConfig } -ArgumentList $exePath
+        Invoke-Command -Session $session -ErrorAction Continue -ErrorVariable err -OutVariable out -scriptBlock { schtasks.exe /create /TN:DTAConfig /TR:$args[0] /F /RL:HIGHEST /SC:MONTHLY; Set-Location $args[1]; schtasks.exe /run /TN:DTAConfig;  schtasks.exe /change /disable /TN:DTAConfig } -ArgumentList $exePath,$vsRoot
 
         Write-Verbose ("Error : {0} " -f ($err | out-string)) -Verbose
         Write-Verbose ("Output : {0} " -f ($out | out-string)) -Verbose

--- a/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
@@ -282,14 +282,14 @@ function Set-TestAgentConfiguration
     {
         $configArgs = $configArgs +  ("/Capabilities:{0}" -f $Capabilities)
     }
-    DeleteDTAAgentExecutionService -ServiceName "DTAAgentExecutionService"
+    DeleteDTAAgentExecutionService -ServiceName "DTAAgentExecutionService" | Out-Null
 
     $configOut = InvokeTestAgentConfigExe -Arguments $configArgs -Version $TestAgentVersion -UserCredential $MachineUserCredential
 
     if ($configOut.ExitCode -eq 0 -and $configAsProcess -eq $true)
     {
         Write-Verbose -Message "Trying to start TestAgent process interactively" -Verbose
-        InvokeDTAExecHostExe -Version $TestAgentVersion -MachineCredential $MachineUserCredential
+        InvokeDTAExecHostExe -Version $TestAgentVersion -MachineCredential $MachineUserCredential | Out-Null
     }
 
     $doReboot = $false
@@ -633,7 +633,7 @@ function InvokeDTAExecHostExe([string] $Version, [System.Management.Automation.P
     Try
     {	   		
 		$session = CreateNewSession -MachineCredential $MachineCredential		
-        Invoke-Command -Session $session -ErrorAction SilentlyContinue -ErrorVariable err -OutVariable out -scriptBlock { schtasks.exe /create /TN:DTAConfig /TR:$args /F /RL:HIGHEST /SC:MONTHLY; schtasks.exe /run /TN:DTAConfig ; schtasks.exe /delete /F /TN:DTAConfig }  -ArgumentList $exePath		
+        Invoke-Command -Session $session -ErrorAction SilentlyContinue -ErrorVariable err -OutVariable out -scriptBlock { schtasks.exe /create /TN:DTAConfig /TR:$args /F /RL:HIGHEST /SC:MONTHLY; schtasks.exe /run /TN:DTAConfig ; schtasks.exe /change /disable /TN:DTAConfig }  -ArgumentList $exePath		
         Write-Verbose -Message ("Error : {0} " -f ($err | out-string)) -Verbose
         Write-Verbose -Message ("Output : {0} " -f ($out | out-string)) -Verbose
     }


### PR DESCRIPTION
1. Removed Date time inputs to the  schtask command 
2. Cleant up command for fetching details of WinRm on the machine
3. Making sure we don't fail if Invoke command return in failure.
Note: We are still rebooting on Win2k8 machine; but it is not impacting user scenario

Testing:
1. Win8.1, Win2012, Win2k8 & Win10 
2. Running as service and running as interactive process
3. Validated running on Azure RG group as well

Bug fixes:
a. Bug 377098:Deploy task fails at 23:59 PM
b. Bug 378527:We should be using cleaner approach for fetcing WinRM details 
