### PR TITLE
Clean build fails if nuget package restore isn't completed first.

### DIFF
--- a/Tasks/MSBuild/MSBuild.ps1
+++ b/Tasks/MSBuild/MSBuild.ps1
@@ -132,14 +132,6 @@ if ("$msbuildLocationMethod".ToUpperInvariant() -eq 'VERSION')
     Write-Verbose "msbuildLocation = $msbuildLocation"
 }
 
-if ($cleanBuild)
-{
-    foreach ($sf in $solutionFiles)  
-    {
-        Invoke-MSBuild $sf -Targets Clean -LogFile "$sf-clean.log" -ToolLocation $msBuildLocation -CommandLineArgs $args -NoTimelineLogger:$noTimelineLogger
-    }
-}
-
 $nugetPath = Get-ToolPath -Name 'NuGet.exe'
 if (-not $nugetPath -and $nugetRestore)
 {
@@ -163,6 +155,11 @@ foreach ($sf in $solutionFiles)
         {
             Write-Verbose "No nuget package configuration files found for $sf"
         }
+    }
+
+    if ($cleanBuild)
+    {
+        Invoke-MSBuild $sf -Targets Clean -LogFile "$sf-clean.log" -ToolLocation $msBuildLocation -CommandLineArgs $args -NoTimelineLogger:$noTimelineLogger
     }
 
     Invoke-MSBuild $sf -LogFile "$sf.log" -ToolLocation $msBuildLocation -CommandLineArgs $args  -NoTimelineLogger:$noTimelineLogger

--- a/Tasks/VSBuild/VSBuild.ps1
+++ b/Tasks/VSBuild/VSBuild.ps1
@@ -176,14 +176,6 @@ if ($vsLocation)
 
 Write-Verbose "args = $args"
 
-if ($cleanBuild)
-{
-    foreach ($sf in $solutionFiles)  
-    {
-        Invoke-MSBuild $sf -Targets Clean -LogFile "$sf-clean.log" -ToolLocation $msBuildLocation -CommandLineArgs $args -NoTimelineLogger:$noTimelineLogger
-    }
-}
-
 $nugetPath = Get-ToolPath -Name 'NuGet.exe'
 if (-not $nugetPath -and $nugetRestore)
 {
@@ -207,6 +199,11 @@ foreach ($sf in $solutionFiles)
         {
             Write-Verbose "No nuget package configuration files found for $sf"
         }
+    }
+
+    if ($cleanBuild)
+    {
+        Invoke-MSBuild $sf -Targets Clean -LogFile "$sf-clean.log" -ToolLocation $msBuildLocation -CommandLineArgs $args -NoTimelineLogger:$noTimelineLogger
     }
 
     Invoke-MSBuild $sf -LogFile "$sf.log" -ToolLocation $msBuildLocation -CommandLineArgs $args  -NoTimelineLogger:$noTimelineLogger


### PR DESCRIPTION
MSBuild failed on clean build if nuget packages weren't restored first.