### PR TITLE
Detecting inactive desktop session

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
@@ -298,7 +298,7 @@ function Set-TestAgentConfiguration
 
     if (IsDtaExecutionHostRunning)
     {
-        Write-Verbose -Message "Killing the existing instances" -Verbose
+        Write-Verbose -Message "Stopping already running instances of DTAExecutionHost" -Verbose
         Stop-Process -processname "DTAExecutionHost"
     }
 

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 8
+        "Patch": 9
     },
     "demands": [
 

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 8
+    "Patch": 9
   },
   "demands": [],
   "minimumAgentVersion": "1.85.0",


### PR DESCRIPTION
Bug 377167:Handle cases when there is no active session (for ex. when user disconnected from remote desktop without running disconnect.bat)

Problem  : When users connected to remote desktop, but disconnected the session without making the console session active, no session remains active. As a result, if testagent gets configured as a process and UI tests are run that interact with the desktop, the tests will fail.

Fix : During testagent configuration, see if there is any active desktop session. If not found, mark the machine for reboot.

Testing : 
	1. 1st time Run as a service (no reboot, non UI test pass)
	2. 1st time Run as a process
		a. while connected via a remote desktop (no reboot, test pass)
		b. while connected via a remote desktop, and the remote desktop session was minimized  (no reboot, UI test failed. Error message from CUIT layer indicates that either the desktop session was locked or minimized, so thats the experience here.)
		c. while connected via a remote desktop, and the remote desktop session was locked (no reboot, UI test failed. Error message from CUIT layer indicates that either the desktop session was locked or minimized, so thats the experience here.)
		d. while connected via a remote desktop, and the remote desktop session was disconnected via disconnect.bat (no reboot, test pass)
		e. while connected via a remote desktop, and the remote desktop session was disconnected normally without disconnect.bat (reboots, test pass)
		f. while connected via a remote desktop, and the remote desktop session was disconnected via windows -> disconnect (reboots, test pass)
		g. when the machine was never logged into (reboots, test pass)
		h. first time configuration (reboots, test pass)
	3. Back to back runs as a process (no reboot, test pass)
	4. Back to back runs as a service. (no reboot, non UI test pass)
	5. Round trip from Process - Service - Process, when no one had ever logged in to the machine
	6. Round trip from Service - Process - Service, when no one had ever logged in to the machine
	7. Run as a service with invalid params, and TestAgentConfig.exe failed, m/c did not reboot
        8. Run as a process with invalid params, and TestAgentConfig.exe failed, m/c not reboot

Ran all above tests on Win2k8r2. On the rest of the OS, cover only sanity tests (2e)