### PR TITLE
Add URL for nuget command line reference to help hint

### DIFF
--- a/Tasks/NuGetInstaller/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/NuGetInstaller/Strings/resources.resjson/en-US/resources.resjson
@@ -12,7 +12,7 @@
   "loc.input.label.noCache": "Disable local cache",
   "loc.input.help.noCache": "Equivalent to the -NoCache NuGet.exe commanline argument",
   "loc.input.label.nuGetRestoreArgs": "NuGet Arguments",
-  "loc.input.help.nuGetRestoreArgs": "Additional arguments passed to NuGet.exe restore.",
+  "loc.input.help.nuGetRestoreArgs": "Additional arguments passed to NuGet.exe restore. See https://docs.nuget.org/consume/command-line-reference#user-content-restore-command.",
   "loc.input.label.nuGetPath": "Path to NuGet.exe",
   "loc.input.help.nuGetPath": "Optionally supply the path to NuGet.exe"
 }

--- a/Tasks/NuGetInstaller/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/NuGetInstaller/Strings/resources.resjson/en-US/resources.resjson
@@ -12,7 +12,7 @@
   "loc.input.label.noCache": "Disable local cache",
   "loc.input.help.noCache": "Equivalent to the -NoCache NuGet.exe commanline argument",
   "loc.input.label.nuGetRestoreArgs": "NuGet Arguments",
-  "loc.input.help.nuGetRestoreArgs": "Additional arguments passed to NuGet.exe restore. See https://docs.nuget.org/consume/command-line-reference#user-content-restore-command.",
+  "loc.input.help.nuGetRestoreArgs": "Additional arguments passed to NuGet.exe restore. [More Information](https://docs.nuget.org/consume/command-line-reference#user-content-restore-command).",
   "loc.input.label.nuGetPath": "Path to NuGet.exe",
   "loc.input.help.nuGetPath": "Optionally supply the path to NuGet.exe"
 }

--- a/Tasks/NuGetInstaller/task.json
+++ b/Tasks/NuGetInstaller/task.json
@@ -43,7 +43,7 @@
             "label": "NuGet Arguments",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Additional arguments passed to NuGet.exe restore."
+            "helpMarkDown": "Additional arguments passed to NuGet.exe restore. See https://docs.nuget.org/consume/command-line-reference#user-content-restore-command."
         },
         {
             "name": "nuGetPath",

--- a/Tasks/NuGetInstaller/task.json
+++ b/Tasks/NuGetInstaller/task.json
@@ -43,7 +43,7 @@
             "label": "NuGet Arguments",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Additional arguments passed to NuGet.exe restore. See https://docs.nuget.org/consume/command-line-reference#user-content-restore-command."
+            "helpMarkDown": "Additional arguments passed to NuGet.exe restore. [More Information](https://docs.nuget.org/consume/command-line-reference#user-content-restore-command)."
         },
         {
             "name": "nuGetPath",


### PR DESCRIPTION
Adds the URL for nuget command line reference to the help hint of the corresponding field in the task.