### PR TITLE
Add link to tfs-cli for uploading custom tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Before writing a task, consider simply customizing your build using the script r
 
 Tasks are simply tool runners.  They know how to run MSBuild, VSTest, etc... in a first class way and handle return codes, how to treat std/err out, and how to write timeline records based on expected output.  They also get access to credentials to write back to VSO/TFS. 
 
+For uploading custom tasks to VSO use the [TFS Cross Platform Command Line utility](https://github.com/Microsoft/tfs-cli).
 
 ## Contributing
 We take contributions.  [Read here](docs/contribute.md) how to contribute.


### PR DESCRIPTION
Add link to tfs-cli for uploading custom tasks to avoid confusion with TaskUploader in this repo. (If there is no reason anymore for TaskUploader it be maybe good to remove it from this repo)