### PR TITLE
Improve hint for MSBuild Solution

### DIFF
--- a/Tasks/MSBuild/task.json
+++ b/Tasks/MSBuild/task.json
@@ -32,7 +32,7 @@
             "label": "Solution", 
             "defaultValue":"**\\*.sln", 
             "required":true,
-            "helpMarkDown": "Relative path from repo root of the solution(s) to run.  Wildcards can be used.  For example, `**\\*.sln` for all sln files in all sub folders."  
+            "helpMarkDown": "Relative path from repo root of the solution(s) or MSBuild project(s) to run.  Wildcards can be used.  For example, `**\\*.sln` for all sln files in all sub folders."
         },
         { 
             "name": "platform", 


### PR DESCRIPTION
Improve description of mark down to make clear that also MSBuild projects can be used.

See also #398 