### PR TITLE
Updating agent version to support Azure SPN

### DIFF
--- a/Tasks/AzureFileCopy/task.json
+++ b/Tasks/AzureFileCopy/task.json
@@ -19,7 +19,7 @@
   "demands": [
     "azureps"
   ],
-  "minimumAgentVersion": "1.85.0",
+  "minimumAgentVersion": "1.86.0",
   "inputs": [
     {
       "name": "ConnectedServiceName",

--- a/Tasks/AzureFileCopy/task.loc.json
+++ b/Tasks/AzureFileCopy/task.loc.json
@@ -22,7 +22,7 @@
   "demands": [
     "azureps"
   ],
-  "minimumAgentVersion": "1.85.0",
+  "minimumAgentVersion": "1.86.0",
   "inputs": [
     {
       "name": "ConnectedServiceName",

--- a/Tasks/DeployAzureResourceGroup/task.json
+++ b/Tasks/DeployAzureResourceGroup/task.json
@@ -19,7 +19,7 @@
     "demands": [
         "azureps"
     ],
-    "minimumAgentVersion": "1.85.0",
+    "minimumAgentVersion": "1.86.0",
     "groups": [
         {
             "name": "advancedDeploymentOptions",

--- a/Tasks/DeployAzureResourceGroup/task.loc.json
+++ b/Tasks/DeployAzureResourceGroup/task.loc.json
@@ -22,7 +22,7 @@
   "demands": [
     "azureps"
   ],
-  "minimumAgentVersion": "1.85.0",
+  "minimumAgentVersion": "1.86.0",
   "groups": [
     {
       "name": "advancedDeploymentOptions",

--- a/Tasks/PerformActionOnMachineGroup/AzureHelper.ps1
+++ b/Tasks/PerformActionOnMachineGroup/AzureHelper.ps1
@@ -96,6 +96,31 @@ function Initialize-AzureHelper
                 }
                 Select-AzureSubscription -SubscriptionId $subscriptionId
             }
+            elseif ($serviceEndpoint.Authorization.Scheme -eq 'ServicePrincipal')
+            {
+	            $servicePrincipalId = $serviceEndpoint.Authorization.Parameters.ServicePrincipalId
+	            $servicePrincipalKey = $serviceEndpoint.Authorization.Parameters.ServicePrincipalKey
+	            $tenantId = $serviceEndpoint.Authorization.Parameters.TenantId
+
+	            Write-Host "tenantId= $tenantId"
+
+	            $securePassword = ConvertTo-SecureString $servicePrincipalKey -AsPlainText -Force
+	            $psCredential = New-Object System.Management.Automation.PSCredential ($servicePrincipalId, $securePassword)
+
+	            Write-Host "Add-AzureAccount -ServicePrincipal -Tenant `$tenantId -Credential `$psCredential"
+	            $azureAccount = Add-AzureAccount -ServicePrincipal -Tenant $tenantId -Credential $psCredential
+	            if (!$azureAccount)
+	            {
+		            throw (Get-LocalizedString -Key "There was an error with the service principal used for deployment")
+	            }
+
+	            $azureSubscriptionId = $serviceEndpoint.Data.SubscriptionId
+	            $azureSubscriptionName = $serviceEndpoint.Data.SubscriptionName
+	            Write-Host "azureSubscriptionId= $azureSubscriptionId"
+	            Write-Host "azureSubscriptionName= $azureSubscriptionName"
+				
+	            Select-AzureSubscription -SubscriptionId $subscriptionId
+            }
             else
             {
                 throw (Get-LocalizedString -Key "Unsupported authorization scheme for azure endpoint = '{0}'" -ArgumentList $serviceEndpoint.Authorization.Scheme)

--- a/Tasks/PerformActionOnMachineGroup/task.json
+++ b/Tasks/PerformActionOnMachineGroup/task.json
@@ -16,7 +16,7 @@
         "Minor": 0,
         "Patch": 9
     },
-    "minimumAgentVersion": "1.86.0",
+    "minimumAgentVersion": "1.87.0",
     "inputs": [ 
         {
             "name": "ConnectedServiceName",

--- a/Tasks/PerformActionOnMachineGroup/task.loc.json
+++ b/Tasks/PerformActionOnMachineGroup/task.loc.json
@@ -19,7 +19,7 @@
     "Minor": 0,
     "Patch": 9
   },
-  "minimumAgentVersion": "1.86.0",
+  "minimumAgentVersion": "1.87.0",
   "inputs": [
     {
       "name": "ConnectedServiceName",

--- a/Tasks/TomcatDeployment/task.json
+++ b/Tasks/TomcatDeployment/task.json
@@ -6,9 +6,7 @@
 	"helpMarkDown": "[More Information](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/TomcatDeployment/README.md)",
     "category": "Deploy",
 	"visibility": [
-        "Preview",
-        "Build",
-        "Release"
+        "Preview"
     ],
     "author": "Microsoft Corporation",
     "version": {

--- a/Tasks/TomcatDeployment/task.loc.json
+++ b/Tasks/TomcatDeployment/task.loc.json
@@ -9,9 +9,7 @@
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Deploy",
   "visibility": [
-    "Preview",
-    "Build",
-    "Release"
+    "Preview"
   ],
   "author": "Microsoft Corporation",
   "version": {


### PR DESCRIPTION
In Sprint 86 we added support for Azure Service principal on agent side, so azure related tasks need to be updated in order to support SPN. Currently Azure Service principal support is under feature flag.