### PR TITLE
XamariniOS: mdtool builds with default solution configuration rather than supplied one

### DIFF
--- a/Tasks/XamariniOS/xamariniOS.js
+++ b/Tasks/XamariniOS/xamariniOS.js
@@ -56,7 +56,7 @@ nugetRunner.exec()
     var mdtoolRunner = new tl.ToolRunner(mdtoolPath);
     mdtoolRunner.arg('--verbose');
     mdtoolRunner.arg('build');
-    mdtoolRunner.arg('--configuration:\'' + configuration + '|' + device + '\'', true);
+    mdtoolRunner.arg('--configuration:' + configuration + '|' + device);
     mdtoolRunner.arg(solutionPath);
 
     // Execute build


### PR DESCRIPTION
Single quotes around the configuration result in mdtool
incorrectly parsing the argument and selecting the default solution
configuration instead of the one passed in the argument. This is probably a hangover from when the toolRunners’ method of execution was changed.

Also, ToolRunner does nothing with the ‘raw’ argument, so we won’t pass it if
we don’t need it.