### PR TITLE
Fixing helpmarkdown string to correctly contain More Information url

### DIFF
--- a/Tasks/Chef/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/Chef/Strings/resources.resjson/de-de/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Chef",
-  "loc.helpMarkDown": "Durch Bearbeiten der Umgebungsattribute in Chef-Umgebungen bereitstellen",
+  "loc.helpMarkDown": "[Weitere Informationen](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Chef/README.md)",
   "loc.description": "Durch Bearbeiten der Umgebungsattribute in Chef-Umgebungen bereitstellen",
   "loc.instanceNameFormat": "Durch Bearbeiten von Umgebungsattributen von Chef-Abonnement $(ChefServer) an Chef bereitstellen",
   "loc.input.label.connectedServiceName": "Chef-Verbindung",

--- a/Tasks/Chef/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/Chef/Strings/resources.resjson/es-es/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Chef",
-  "loc.helpMarkDown": "Implementar en entornos de Chef editando los atributos de entorno",
+  "loc.helpMarkDown": "[Más información](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Chef/README.md)",
   "loc.description": "Realice implementaciones en entornos Chef mediante la edición de los atributos del entorno",
   "loc.instanceNameFormat": "Implementar en Chef editando los atributos de entorno de la suscripción de Chef $(ChefServer)",
   "loc.input.label.connectedServiceName": "Conexión Chef",

--- a/Tasks/Chef/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/Chef/Strings/resources.resjson/fr-fr/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Chef",
-  "loc.helpMarkDown": "Déployer dans des environnements Chef en modifiant les attributs d'environnement",
+  "loc.helpMarkDown": "[Plus d'informations](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Chef/README.md)",
   "loc.description": "Déployer dans des environnements Chef en modifiant les attributs d'environnement",
   "loc.instanceNameFormat": "Déployer dans un environnement chef en modifiant les attributs d'environnement de l'abonnement Chef $(ChefServer)",
   "loc.input.label.connectedServiceName": "Connexion Chef",

--- a/Tasks/Chef/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/Chef/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Chef",
-  "loc.helpMarkDown": "Consente di distribuire in ambienti Chef modificando gli attributi dell'ambiente",
+  "loc.helpMarkDown": "[Altre informazioni](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Chef/README.md)",
   "loc.description": "Consente di distribuire in ambienti Chef modificando gli attributi dell'ambiente",
   "loc.instanceNameFormat": "Consente di distribuire in Chef modificando gli attributi di ambiente della sottoscrizione di Chef $(ChefServer)",
   "loc.input.label.connectedServiceName": "Connessione a Chef",

--- a/Tasks/Chef/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/Chef/Strings/resources.resjson/ja-jp/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Chef",
-  "loc.helpMarkDown": "環境属性を編集して Chef 環境を展開します",
+  "loc.helpMarkDown": "[詳細](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Chef/README.md)",
   "loc.description": "環境属性を編集して Chef 環境を展開します",
   "loc.instanceNameFormat": "Chef のサブスクリプション $(ChefServer) の環境属性を編集して Chef に展開します",
   "loc.input.label.connectedServiceName": "Chef 接続",

--- a/Tasks/Chef/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/Chef/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Chef",
-  "loc.helpMarkDown": "환경 특성을 편집하여 Chef 환경에 배포",
+  "loc.helpMarkDown": "[자세한 정보](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Chef/README.md)",
   "loc.description": "환경 특성을 편집하여 Chef 환경에 배포",
   "loc.instanceNameFormat": "Chef 구독 $(ChefServer)의 환경 특성을 편집하여 chef에 배포",
   "loc.input.label.connectedServiceName": "Chef 연결",

--- a/Tasks/Chef/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/Chef/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Chef",
-  "loc.helpMarkDown": "Развертывание в средах Chef путем изменения атрибутов среды",
+  "loc.helpMarkDown": "[Подробнее](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Chef/README.md)",
   "loc.description": "Развертывание в средах Chef путем изменения атрибутов среды",
   "loc.instanceNameFormat": "Выполните развертывание в Сhef, изменив атрибуты среды для подписки Chef $(ChefServer)",
   "loc.input.label.connectedServiceName": "Подключение Chef",

--- a/Tasks/Chef/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/Chef/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Chef",
-  "loc.helpMarkDown": "通过编辑环境属性部署到 Chef 环境",
+  "loc.helpMarkDown": "[详细信息](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Chef/README.md)",
   "loc.description": "通过编辑环境属性部署到 Chef 环境",
   "loc.instanceNameFormat": "通过编辑 Chef 订阅 $(ChefServer) 的环境属性来部署到 chef",
   "loc.input.label.connectedServiceName": "Chef 连接",

--- a/Tasks/Chef/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/Chef/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Chef",
-  "loc.helpMarkDown": "編輯環境屬性，以部署至 Chef 環境",
+  "loc.helpMarkDown": "[詳細資訊](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Chef/README.md)",
   "loc.description": "編輯環境屬性，以部署至 Chef 環境",
   "loc.instanceNameFormat": "編輯 Chef 訂用帳戶的環境屬性以部署至 Chef $(ChefServer)",
   "loc.input.label.connectedServiceName": "Chef 連接",

--- a/Tasks/ChefKnife/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/ChefKnife/Strings/resources.resjson/de-de/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Chef Knife",
-  "loc.helpMarkDown": "Skripte mit Knife-Befehlen auf Ihrer Chef-Arbeitsstation ausführen",
+  "loc.helpMarkDown": "[Weitere Informationen](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/ChefKnife/README.md)",
   "loc.description": "Skripte mit Knife-Befehlen auf Ihrer Chef-Arbeitsstation ausführen",
   "loc.instanceNameFormat": "Chef Knife-Skript: $(ScriptPath)",
   "loc.input.label.ConnectedServiceName": "Chef-Abonnements",

--- a/Tasks/ChefKnife/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/ChefKnife/Strings/resources.resjson/es-es/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Knife de Chef",
-  "loc.helpMarkDown": "Ejecutar scripts con comandos knife en la estación de trabajo de Chef",
+  "loc.helpMarkDown": "[Más información](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/ChefKnife/README.md)",
   "loc.description": "Ejecute scripts con comandos Knife en la estación de trabajo Chef",
   "loc.instanceNameFormat": "Script knife de Chef: $(ScriptPath)",
   "loc.input.label.ConnectedServiceName": "Suscripción a Chef",

--- a/Tasks/ChefKnife/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/ChefKnife/Strings/resources.resjson/fr-fr/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Knife pour Chef",
-  "loc.helpMarkDown": "Exécuter des scripts avec des commandes knife sur votre station de travail chef",
+  "loc.helpMarkDown": "[Plus d'informations](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/ChefKnife/README.md)",
   "loc.description": "Exécuter des scripts avec des commandes knife sur votre station de travail chef",
   "loc.instanceNameFormat": "Script Chef Knife : $(ScriptPath)",
   "loc.input.label.ConnectedServiceName": "Abonnement Chef",

--- a/Tasks/ChefKnife/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/ChefKnife/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Knife Chef",
-  "loc.helpMarkDown": "Consente di eseguire script con comandi knife sulla workstation Chef",
+  "loc.helpMarkDown": "[Altre informazioni](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/ChefKnife/README.md)",
   "loc.description": "Consente di eseguire script con comandi knife sulla workstation Chef",
   "loc.instanceNameFormat": "Script knife Chef: $(ScriptPath)",
   "loc.input.label.ConnectedServiceName": "Sottoscrizione di Chef",

--- a/Tasks/ChefKnife/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/ChefKnife/Strings/resources.resjson/ja-jp/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Chef Knife",
-  "loc.helpMarkDown": "Chef ワークステーションで knife コマンドを使ってスクリプトを実行します",
+  "loc.helpMarkDown": "[詳細](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/ChefKnife/README.md)",
   "loc.description": "Chef ワークステーションで knife コマンドを使ってスクリプトを実行します",
   "loc.instanceNameFormat": "Chef の knife スクリプト: $(ScriptPath)",
   "loc.input.label.ConnectedServiceName": "Chef サブスクリプション",

--- a/Tasks/ChefKnife/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/ChefKnife/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Chef Knife",
-  "loc.helpMarkDown": "chef 워크스테이션에서 knife 명령을 사용하여 스크립트 실행",
+  "loc.helpMarkDown": "[자세한 정보](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/ChefKnife/README.md)",
   "loc.description": "chef 워크스테이션에서 knife 명령을 사용하여 스크립트 실행",
   "loc.instanceNameFormat": "Chef Knife 스크립트: $(ScriptPath)",
   "loc.input.label.ConnectedServiceName": "Chef 구독",

--- a/Tasks/ChefKnife/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/ChefKnife/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Chef Knife",
-  "loc.helpMarkDown": "Выполнение сценариев с помощью команд Knife на рабочей станции Chef",
+  "loc.helpMarkDown": "[Подробнее](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/ChefKnife/README.md)",
   "loc.description": "Выполнение скриптов с помощью команд Knife на рабочей станции Chef",
   "loc.instanceNameFormat": "Сценарий Knife Chef: $(ScriptPath)",
   "loc.input.label.ConnectedServiceName": "Подписка Chef",

--- a/Tasks/ChefKnife/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/ChefKnife/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Chef Knife",
-  "loc.helpMarkDown": "在 chef 工作站上使用 knife 命令运行脚本",
+  "loc.helpMarkDown": "[详细信息](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/ChefKnife/README.md)",
   "loc.description": "在 chef 工作站上使用 knife 命令运行脚本",
   "loc.instanceNameFormat": "Chef Knife 脚本: $(ScriptPath)",
   "loc.input.label.ConnectedServiceName": "Chef 订阅",

--- a/Tasks/ChefKnife/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/ChefKnife/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Chef Knife",
-  "loc.helpMarkDown": "在您 Chef 工作站上使用 knife 命令執行指令碼。",
+  "loc.helpMarkDown": "[詳細資訊](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/ChefKnife/README.md)",
   "loc.description": "在您 Chef 工作站上使用 knife 命令執行指令碼。",
   "loc.instanceNameFormat": "Chef Knife 指令碼: $(ScriptPath)",
   "loc.input.label.ConnectedServiceName": "Chef 訂用帳戶",

--- a/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/de-de/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Azure-Ressourcengruppe bereitstellen",
-  "loc.helpMarkDown": "Azure-Ressourcengruppe bereitstellen",
+  "loc.helpMarkDown": "[Weitere Informationen](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployAzureResourceGroup/README.md)",
   "loc.description": "Azure-Ressourcengruppe bereitstellen",
   "loc.instanceNameFormat": "Azure-Bereitstellung: $(resourceGroupName)",
   "loc.group.displayName.advancedDeploymentOptions": "Erweiterte Bereitstellungsoptionen",

--- a/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/es-es/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Implementar un grupo de recursos de Azure",
-  "loc.helpMarkDown": "Aprovisionar e implementar un grupo de recursos de Azure",
+  "loc.helpMarkDown": "[Más información](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployAzureResourceGroup/README.md)",
   "loc.description": "Aprovisione e implemente un grupo de recursos de Azure",
   "loc.instanceNameFormat": "Implementación de Azure: $(resourceGroupName)",
   "loc.group.displayName.advancedDeploymentOptions": "Opciones de implementación avanzadas",

--- a/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/fr-fr/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Déployer un groupe de ressources Azure",
-  "loc.helpMarkDown": "Approvisionner et déployer un groupe de ressources Azure",
+  "loc.helpMarkDown": "[Plus d'informations](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployAzureResourceGroup/README.md)",
   "loc.description": "Approvisionner et déployer un groupe de ressources Azure",
   "loc.instanceNameFormat": "Déploiement Azure : $(resourceGroupName)",
   "loc.group.displayName.advancedDeploymentOptions": "Options de déploiement avancées",

--- a/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Distribuisci gruppo di risorse di Azure",
-  "loc.helpMarkDown": "Consente di effettuare il provisioning e la distribuzione di un gruppo di risorse di Azure",
+  "loc.helpMarkDown": "[Altre informazioni](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployAzureResourceGroup/README.md)",
   "loc.description": "Consente di effettuare il provisioning e la distribuzione di un gruppo di risorse di Azure",
   "loc.instanceNameFormat": "Distribuzione Azure: $(resourceGroupName)",
   "loc.group.displayName.advancedDeploymentOptions": "Opzioni di distribuzione avanzate",

--- a/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/ja-jp/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Azure リソース グループの展開",
-  "loc.helpMarkDown": "Azure リソース グループをプロビジョニングし、展開します",
+  "loc.helpMarkDown": "[詳細](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployAzureResourceGroup/README.md)",
   "loc.description": "Azure リソース グループをプロビジョニングし、展開します",
   "loc.instanceNameFormat": "Azure の展開: $(resourceGroupName)",
   "loc.group.displayName.advancedDeploymentOptions": "詳細な展開オプション",

--- a/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Azure 리소스 그룹 배포",
-  "loc.helpMarkDown": "Azure 리소스 그룹 프로비전 및 배포",
+  "loc.helpMarkDown": "[자세한 정보](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployAzureResourceGroup/README.md)",
   "loc.description": "Azure 리소스 그룹 프로비전 및 배포",
   "loc.instanceNameFormat": "Azure 배포: $(resourceGroupName)",
   "loc.group.displayName.advancedDeploymentOptions": "배포 고급 옵션",

--- a/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Развертывание группы ресурсов Azure",
-  "loc.helpMarkDown": "Подготовка и развертывание группы ресурсов Azure",
+  "loc.helpMarkDown": "[Подробнее](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployAzureResourceGroup/README.md)",
   "loc.description": "Подготовка и развертывание группы ресурсов Azure",
   "loc.instanceNameFormat": "Развертывание Azure: $(resourceGroupName)",
   "loc.group.displayName.advancedDeploymentOptions": "Расширенные параметры развертывания",

--- a/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "部署 Azure 资源组",
-  "loc.helpMarkDown": "设置并部署 Azure 资源组",
+  "loc.helpMarkDown": "[详细信息](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployAzureResourceGroup/README.md)",
   "loc.description": "设置并部署 Azure 资源组",
   "loc.instanceNameFormat": "Azure 部署: $(resourceGroupName)",
   "loc.group.displayName.advancedDeploymentOptions": "高级部署选项",

--- a/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/DeployAzureResourceGroup/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "部署 Azure 資源群組",
-  "loc.helpMarkDown": "佈建及部署 Azure 資源群組",
+  "loc.helpMarkDown": "[詳細資訊](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployAzureResourceGroup/README.md)",
   "loc.description": "佈建及部署 Azure 資源群組",
   "loc.instanceNameFormat": "Azure 部署: $(resourceGroupName)",
   "loc.group.displayName.advancedDeploymentOptions": "進階部署選項",

--- a/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/de-de/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Visual Studio Test Agent-Bereitstellung",
-  "loc.helpMarkDown": "Test-Agent für die Ausführung von Tests auf einer Lab-Computergruppe bereitstellen und konfigurieren",
+  "loc.helpMarkDown": "[Weitere Informationen](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployVisualStudioTestAgent/README.md)",
   "loc.description": "Test-Agent für die Ausführung von Tests auf einer Lab-Computergruppe bereitstellen und konfigurieren",
   "loc.instanceNameFormat": "TestAgent auf $(testMachineGroup) bereitstellen",
   "loc.group.displayName.testMachineGroups": "Testcomputergruppe",

--- a/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/es-es/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Implementación de Visual Studio Test Agent",
-  "loc.helpMarkDown": "Implementar y configurar Test Agent para que ejecute pruebas en un grupo de equipos de laboratorio",
+  "loc.helpMarkDown": "[Más información](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployVisualStudioTestAgent/README.md)",
   "loc.description": "Implementar y configurar Test Agent para que ejecute pruebas en un grupo de equipos de laboratorio",
   "loc.instanceNameFormat": "Implementar TestAgent en $(testMachineGroup)",
   "loc.group.displayName.testMachineGroups": "Grupo de equipos de prueba",

--- a/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/fr-fr/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Déploiement de Visual Studio Test Agent",
-  "loc.helpMarkDown": "Déployer et configurer Test Agent pour exécuter des tests sur un groupe d'ordinateurs lab",
+  "loc.helpMarkDown": "[Plus d'informations](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployVisualStudioTestAgent/README.md)",
   "loc.description": "Déployer et configurer Test Agent pour exécuter des tests sur un groupe d'ordinateurs lab",
   "loc.instanceNameFormat": "Déployer TestAgent sur $(testMachineGroup)",
   "loc.group.displayName.testMachineGroups": "Groupe d'ordinateurs de test",

--- a/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Distribuzione agente di test di Visual Studio",
-  "loc.helpMarkDown": "Consente di distribuire e configurare l'agente di test per eseguire test su un gruppo di computer lab",
+  "loc.helpMarkDown": "[Altre informazioni](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployVisualStudioTestAgent/README.md)",
   "loc.description": "Consente di distribuire e configurare l'agente di test per eseguire test su un gruppo di computer lab",
   "loc.instanceNameFormat": "Distribuisci agente di test in $(testMachineGroup)",
   "loc.group.displayName.testMachineGroups": "Gruppo di computer di test",

--- a/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/ja-jp/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Visual Studio Test Agent の展開",
-  "loc.helpMarkDown": "ラボのコンピューター グループでテストを実行するために Test Agent を展開および構成します",
+  "loc.helpMarkDown": "[詳細](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployVisualStudioTestAgent/README.md)",
   "loc.description": "ラボのコンピューター グループでテストを実行するために Test Agent を展開および構成します",
   "loc.instanceNameFormat": "TestAgent を $(testMachineGroup) に展開",
   "loc.group.displayName.testMachineGroups": "テスト コンピューター グループ",

--- a/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Visual Studio 테스트 에이전트 배포",
-  "loc.helpMarkDown": "테스트 에이전트를 배포 및 구성하여 랩 컴퓨터 그룹에서 테스트 실행",
+  "loc.helpMarkDown": "[자세한 정보](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployVisualStudioTestAgent/README.md)",
   "loc.description": "테스트 에이전트를 배포 및 구성하여 랩 컴퓨터 그룹에서 테스트 실행",
   "loc.instanceNameFormat": "$(testMachineGroup)에서 테스트에이전트 배포",
   "loc.group.displayName.testMachineGroups": "테스트 컴퓨터 그룹",

--- a/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Развертывание агента тестирования Visual Studio",
-  "loc.helpMarkDown": "Разверните и настройте агент тестирования для выполнения тестов в группе лабораторных машин",
+  "loc.helpMarkDown": "[Подробнее](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployVisualStudioTestAgent/README.md)",
   "loc.description": "Разверните и настройте агент тестирования для выполнения тестов в группе лабораторных машин",
   "loc.instanceNameFormat": "Развернуть агент тестирования в $(testMachineGroup)",
   "loc.group.displayName.testMachineGroups": "Группа тестовых машин",

--- a/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Visual Studio Test Agent 部署",
-  "loc.helpMarkDown": "部署并配置 Test Agent 以对实验室计算机组运行测试",
+  "loc.helpMarkDown": "[详细信息](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployVisualStudioTestAgent/README.md)",
   "loc.description": "部署并配置 Test Agent 以对实验室计算机组运行测试",
   "loc.instanceNameFormat": "在 $(testMachineGroup) 上部署测试代理",
   "loc.group.displayName.testMachineGroups": "测试计算机组",

--- a/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/DeployVisualStudioTestAgent/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Visual Studio Test Agent 部署",
-  "loc.helpMarkDown": "部署及設定 Test Agent 以在實驗室電腦群組上執行測試",
+  "loc.helpMarkDown": "[詳細資訊](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployVisualStudioTestAgent/README.md)",
   "loc.description": "部署及設定 Test Agent 以在實驗室電腦群組上執行測試",
   "loc.instanceNameFormat": "在 $(testMachineGroup) 部署測試代理程式",
   "loc.group.displayName.testMachineGroups": "測試電腦群組",

--- a/Tasks/Docker/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/Docker/Strings/resources.resjson/de-de/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Docker",
-  "loc.helpMarkDown": "Docker-Image auf einem Remotecomputer bereitstellen",
+  "loc.helpMarkDown": "[Weitere Informationen](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Docker/README.md)",
   "loc.description": "Docker-Image auf einem Remotecomputer bereitstellen",
   "loc.instanceNameFormat": "Docker-Bereitstellung: $(Repository)",
   "loc.input.label.DockerEndpoint": "Docker-Endpunkt",

--- a/Tasks/Docker/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/Docker/Strings/resources.resjson/es-es/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Docker",
-  "loc.helpMarkDown": "Implementar una imagen de Docker en un equipo remoto",
+  "loc.helpMarkDown": "[Más información](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Docker/README.md)",
   "loc.description": "Implemente una imagen de Docker en una máquina remota",
   "loc.instanceNameFormat": "Implementación de Docker: $(Repository)",
   "loc.input.label.DockerEndpoint": "Extremo de Docker",

--- a/Tasks/Docker/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/Docker/Strings/resources.resjson/fr-fr/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Docker",
-  "loc.helpMarkDown": "Déployer une image Docker sur un ordinateur distant",
+  "loc.helpMarkDown": "[Plus d'informations](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Docker/README.md)",
   "loc.description": "Déployer une image Docker sur un ordinateur distant",
   "loc.instanceNameFormat": "Déploiement de Docker : $(Repository)",
   "loc.input.label.DockerEndpoint": "Point de terminaison Docker",

--- a/Tasks/Docker/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/Docker/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Docker",
-  "loc.helpMarkDown": "Consente di distribuire un'immagine Docker in un computer remoto",
+  "loc.helpMarkDown": "[Altre informazioni](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Docker/README.md)",
   "loc.description": "Consente di distribuire un'immagine Docker in un computer remoto",
   "loc.instanceNameFormat": "Distribuzione Docker: $(Repository)",
   "loc.input.label.DockerEndpoint": "Endpoint Docker",

--- a/Tasks/Docker/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/Docker/Strings/resources.resjson/ja-jp/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Docker",
-  "loc.helpMarkDown": "Docker イメージをリモート コンピューターに展開します",
+  "loc.helpMarkDown": "[詳細](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Docker/README.md)",
   "loc.description": "Docker イメージをリモート コンピューターに展開します",
   "loc.instanceNameFormat": "Docker の展開: $(Repository)",
   "loc.input.label.DockerEndpoint": "Docker エンドポイント",

--- a/Tasks/Docker/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/Docker/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Docker",
-  "loc.helpMarkDown": "원격 컴퓨터에 Docker 이미지 배포",
+  "loc.helpMarkDown": "[자세한 정보](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Docker/README.md)",
   "loc.description": "원격 컴퓨터에 Docker 이미지 배포",
   "loc.instanceNameFormat": "Docker 배포: $(Repository)",
   "loc.input.label.DockerEndpoint": "Docker 끝점",

--- a/Tasks/Docker/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/Docker/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Docker",
-  "loc.helpMarkDown": "Развертывание образа Docker на удаленном компьютере",
+  "loc.helpMarkDown": "[Подробнее](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Docker/README.md)",
   "loc.description": "Развертывание образа Docker на удаленном компьютере",
   "loc.instanceNameFormat": "Развертывание Docker: $(Repository)",
   "loc.input.label.DockerEndpoint": "Конечная точка Docker",

--- a/Tasks/Docker/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/Docker/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "泊坞窗",
-  "loc.helpMarkDown": "将泊坞窗图像部署到远程计算机",
+  "loc.helpMarkDown": "[详细信息](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Docker/README.md)",
   "loc.description": "将泊坞窗图像部署到远程计算机",
   "loc.instanceNameFormat": "泊坞窗部署: $(Repository)",
   "loc.input.label.DockerEndpoint": "泊坞窗终结点",

--- a/Tasks/Docker/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/Docker/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Docker",
-  "loc.helpMarkDown": "將 Docker 映像部署到遠端電腦",
+  "loc.helpMarkDown": "[詳細資訊](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/Docker/README.md)",
   "loc.description": "將 Docker 映像部署到遠端電腦",
   "loc.instanceNameFormat": "Docker 部署: $(Repository)",
   "loc.input.label.DockerEndpoint": "Docker 端點",

--- a/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/de-de/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Computergruppenaktionen",
-  "loc.helpMarkDown": "Aktionen wie Starten, Beenden oder Löschen für eine Computergruppe ausführen",
+  "loc.helpMarkDown": "[Weitere Informationen](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PerformActionOnMachineGroup/README.md)",
   "loc.description": "Computergruppenaktionen",
   "loc.instanceNameFormat": "Computergruppe $(Action)",
   "loc.input.label.MachineGroupName": "Computergruppe",

--- a/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/es-es/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Acciones de grupo de equipos",
-  "loc.helpMarkDown": "Realice acciones como iniciar, detener o eliminar en un grupo de equipos",
+  "loc.helpMarkDown": "[Más información](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PerformActionOnMachineGroup/README.md)",
   "loc.description": "Acciones de grupo de equipos",
   "loc.instanceNameFormat": "$(Action) grupo de equipos ",
   "loc.input.label.MachineGroupName": "Grupo de equipos",

--- a/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/fr-fr/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Actions du groupe d'ordinateurs",
-  "loc.helpMarkDown": "Effectuer des actions telles que start, stop et delete sur un groupe d'ordinateurs",
+  "loc.helpMarkDown": "[Plus d'informations](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PerformActionOnMachineGroup/README.md)",
   "loc.description": "Actions du groupe d'ordinateurs",
   "loc.instanceNameFormat": "$(Action) groupe d'ordinateurs ",
   "loc.input.label.MachineGroupName": "Groupe d'ordinateurs",

--- a/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Azioni del gruppo di computer",
-  "loc.helpMarkDown": "Consente di eseguire azioni, come start, stop o delete su un gruppo di computer",
+  "loc.helpMarkDown": "[Altre informazioni](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PerformActionOnMachineGroup/README.md)",
   "loc.description": "Azioni del gruppo di computer",
   "loc.instanceNameFormat": "$(Action) gruppo di computer ",
   "loc.input.label.MachineGroupName": "Gruppo di computer",

--- a/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/ja-jp/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "コンピューター グループ アクション",
-  "loc.helpMarkDown": "コンピューター グループで、開始、停止、削除などのアクションを実行します",
+  "loc.helpMarkDown": "[詳細](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PerformActionOnMachineGroup/README.md)",
   "loc.description": "コンピューター グループ アクション",
   "loc.instanceNameFormat": "$(アクション) コンピューター グループ",
   "loc.input.label.MachineGroupName": "コンピューター グループ",

--- a/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "컴퓨터 그룹 작업",
-  "loc.helpMarkDown": "컴퓨터 그룹에 대해 시작, 중지, 삭제와 같은 작업을 수행합니다.",
+  "loc.helpMarkDown": "[자세한 정보](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PerformActionOnMachineGroup/README.md)",
   "loc.description": "컴퓨터 그룹 작업",
   "loc.instanceNameFormat": "컴퓨터 그룹 $(Action)",
   "loc.input.label.MachineGroupName": "컴퓨터 그룹",

--- a/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Действия с группой машин",
-  "loc.helpMarkDown": "Выполнение действий с группой машин, таких как запуск, остановка или удаление",
+  "loc.helpMarkDown": "[Подробнее](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PerformActionOnMachineGroup/README.md)",
   "loc.description": "Действия с группой машин",
   "loc.instanceNameFormat": "Группа машин $(Action) ",
   "loc.input.label.MachineGroupName": "Группа машин",

--- a/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "计算机组操作",
-  "loc.helpMarkDown": "对计算机组执行操作(如启动、停止、删除)",
+  "loc.helpMarkDown": "[详细信息](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PerformActionOnMachineGroup/README.md)",
   "loc.description": "计算机组操作",
   "loc.instanceNameFormat": "$(Action) 计算机组 ",
   "loc.input.label.MachineGroupName": "计算机组",

--- a/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/PerformActionOnMachineGroup/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "電腦群組動作",
-  "loc.helpMarkDown": "在電腦群組上執行動作 (例如開始、停止、刪除)",
+  "loc.helpMarkDown": "[詳細資訊](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PerformActionOnMachineGroup/README.md)",
   "loc.description": "電腦群組動作",
   "loc.instanceNameFormat": "$(Action) 電腦群組 ",
   "loc.input.label.MachineGroupName": "電腦群組",

--- a/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/de-de/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "PowerShell auf Zielcomputern",
-  "loc.helpMarkDown": "PowerShell-Skripte auf Remotecomputern ausführen",
+  "loc.helpMarkDown": "[Weitere Informationen](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PowerShellOnTargetMachines/README.md)",
   "loc.description": "PowerShell-Skripte auf Remotecomputern ausführen",
   "loc.instanceNameFormat": "PowerShell in $(EnvironmentName) ausführen",
   "loc.group.displayName.advanced": "Erweitert",

--- a/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/es-es/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "PowerShell en equipos de destino",
-  "loc.helpMarkDown": "Ejecutar scripts de PowerShell en equipo(s) remoto(s)",
+  "loc.helpMarkDown": "[Más información](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PowerShellOnTargetMachines/README.md)",
   "loc.description": "Ejecutar scripts de PowerShell en equipo(s) remoto(s)",
   "loc.instanceNameFormat": "Ejecutar PowerShell en $(EnvironmentName)",
   "loc.group.displayName.advanced": "Avanzado",

--- a/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/fr-fr/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "PowerShell sur des ordinateurs cibles",
-  "loc.helpMarkDown": "Exécuter des scripts PowerShell sur des ordinateurs distants",
+  "loc.helpMarkDown": "[Plus d'informations](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PowerShellOnTargetMachines/README.md)",
   "loc.description": "Exécuter des scripts PowerShell sur des ordinateurs distants",
   "loc.instanceNameFormat": "Exécuter PowerShell sur $(EnvironmentName)",
   "loc.group.displayName.advanced": "Avancé",

--- a/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "PowerShell in computer di destinazione",
-  "loc.helpMarkDown": "Consente di eseguire script PowerShell nei computer remoti",
+  "loc.helpMarkDown": "[Altre informazioni](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PowerShellOnTargetMachines/README.md)",
   "loc.description": "Consente di eseguire script PowerShell nei computer remoti",
   "loc.instanceNameFormat": "Esegui PowerShell in $(EnvironmentName)",
   "loc.group.displayName.advanced": "Avanzate",

--- a/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/ja-jp/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "ターゲット コンピューターでの PowerShell",
-  "loc.helpMarkDown": "リモート コンピューター (複数可) で PowerShell スクリプトを実行します",
+  "loc.helpMarkDown": "[詳細](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PowerShellOnTargetMachines/README.md)",
   "loc.description": "リモート コンピューター (複数可) で PowerShell スクリプトを実行します",
   "loc.instanceNameFormat": "$(EnvironmentName) での PowerShell の実行",
   "loc.group.displayName.advanced": "詳細設定",

--- a/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "대상 컴퓨터의 PowerShell",
-  "loc.helpMarkDown": "원격 컴퓨터에서 PowerShell 스크립트 실행",
+  "loc.helpMarkDown": "[자세한 정보](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PowerShellOnTargetMachines/README.md)",
   "loc.description": "원격 컴퓨터에서 PowerShell 스크립트 실행",
   "loc.instanceNameFormat": "$(EnvironmentName)에서 PowerShell 실행",
   "loc.group.displayName.advanced": "고급",

--- a/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "PowerShell на целевых компьютерах",
-  "loc.helpMarkDown": "Выполнять сценарии PowerShell на удаленных компьютерах",
+  "loc.helpMarkDown": "[Подробнее](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PowerShellOnTargetMachines/README.md)",
   "loc.description": "Выполнять сценарии PowerShell на удаленных компьютерах",
   "loc.instanceNameFormat": "Выполнить PowerShell в $(EnvironmentName)",
   "loc.group.displayName.advanced": "Дополнительно",

--- a/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "目标计算机上的 PowerShell",
-  "loc.helpMarkDown": "在远程计算机上执行 PowerShell 脚本",
+  "loc.helpMarkDown": "[详细信息](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PowerShellOnTargetMachines/README.md)",
   "loc.description": "在远程计算机上执行 PowerShell 脚本",
   "loc.instanceNameFormat": "在 $(EnvironmentName) 上运行 PowerShell",
   "loc.group.displayName.advanced": "高级",

--- a/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/PowerShellOnTargetMachines/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "目標電腦上的 PowerShell",
-  "loc.helpMarkDown": "在遠端電腦上執行 PowerShell 指令碼。",
+  "loc.helpMarkDown": "[詳細資訊](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/PowerShellOnTargetMachines/README.md)",
   "loc.description": "在遠端電腦上執行 PowerShell 指令碼。",
   "loc.instanceNameFormat": "在 $(EnvironmentName) 執行 PowerShell",
   "loc.group.displayName.advanced": "進階",

--- a/Tasks/RunDistributedTests/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/RunDistributedTests/Strings/resources.resjson/de-de/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Visual Studio-Test mit Test-Agent",
-  "loc.helpMarkDown": "Tests verteilt mithilfe mehrerer Test-Agents in einer Lab-Computergruppe ausführen",
+  "loc.helpMarkDown": "[Weitere Informationen](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/RunDistributedTests/README.md)",
   "loc.description": "Tests verteilt mithilfe mehrerer Test-Agents in einer Lab-Computergruppe ausführen",
   "loc.instanceNameFormat": "Tests $(sourcefilters) für $(testMachineGroup) ausführen",
   "loc.group.displayName.testMachineGroups": "Testcomputergruppe",

--- a/Tasks/RunDistributedTests/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/RunDistributedTests/Strings/resources.resjson/es-es/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Prueba de Visual Studio con Test Agent",
-  "loc.helpMarkDown": "Ejecutar pruebas de forma distribuida con varios agentes de pruebas en un grupo de equipos de laboratorio",
+  "loc.helpMarkDown": "[Más información](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/RunDistributedTests/README.md)",
   "loc.description": "Ejecutar pruebas de forma distribuida con varios agentes de pruebas en un grupo de equipos de laboratorio",
   "loc.instanceNameFormat": "Ejecutar pruebas $(sourcefilters) en $(testMachineGroup)",
   "loc.group.displayName.testMachineGroups": "Grupo de equipos de prueba",

--- a/Tasks/RunDistributedTests/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/RunDistributedTests/Strings/resources.resjson/fr-fr/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Test Visual Studio à l'aide de l'agent de test",
-  "loc.helpMarkDown": "Exécuter des tests de façon distribuée à l'aide de plusieurs agents de test dans un groupe d'ordinateurs lab",
+  "loc.helpMarkDown": "[Plus d'informations](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/RunDistributedTests/README.md)",
   "loc.description": "Exécuter des tests de façon distribuée à l'aide de plusieurs agents de test dans un groupe d'ordinateurs lab",
   "loc.instanceNameFormat": "Exécuter les tests $(sourcefilters) sur $(testMachineGroup)",
   "loc.group.displayName.testMachineGroups": "Groupe d'ordinateurs de test",

--- a/Tasks/RunDistributedTests/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/RunDistributedTests/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Test di Visual Studio con agente di test",
-  "loc.helpMarkDown": "Consente di eseguire i test in modalità distribuita usando più agenti di test in un gruppo di computer lab.",
+  "loc.helpMarkDown": "[Altre informazioni](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/RunDistributedTests/README.md)",
   "loc.description": "Consente di eseguire i test in modalità distribuita usando più agenti di test in un gruppo di computer lab.",
   "loc.instanceNameFormat": "Esegui test $(sourcefilters) in $(testMachineGroup)",
   "loc.group.displayName.testMachineGroups": "Gruppo di computer di test",

--- a/Tasks/RunDistributedTests/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/RunDistributedTests/Strings/resources.resjson/ja-jp/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "テスト エージェントを使用した Visual Studio テスト",
-  "loc.helpMarkDown": "ラボ コンピューター グループ内の複数のテスト エージェントを使用して、テストを分散して実行します。",
+  "loc.helpMarkDown": "[詳細](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/RunDistributedTests/README.md)",
   "loc.description": "ラボ コンピューター グループ内の複数のテスト エージェントを使用して、テストを分散して実行します。",
   "loc.instanceNameFormat": "$(testMachineGroup) でのテスト $(sourcefilters) の実行",
   "loc.group.displayName.testMachineGroups": "テスト コンピューター グループ",

--- a/Tasks/RunDistributedTests/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/RunDistributedTests/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "테스트 에이전트를 사용하여 Visual Studio 테스트",
-  "loc.helpMarkDown": "랩 컴퓨터 그룹에서 여러 테스트 에이전트를 사용하여 테스트를 분산되게 실행합니다.",
+  "loc.helpMarkDown": "[자세한 정보](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/RunDistributedTests/README.md)",
   "loc.description": "랩 컴퓨터 그룹에서 여러 테스트 에이전트를 사용하여 테스트를 분산되게 실행합니다.",
   "loc.instanceNameFormat": "$(testMachineGroup)에서 테스트 $(sourcefilters) 실행",
   "loc.group.displayName.testMachineGroups": "테스트 컴퓨터 그룹",

--- a/Tasks/RunDistributedTests/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/RunDistributedTests/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Тест Visual Studio с использованием агента тестирования",
-  "loc.helpMarkDown": "Распределенный запуск тестов с помощью нескольких агентов тестирования в группе компьютеров лаборатории",
+  "loc.helpMarkDown": "[Подробнее](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/RunDistributedTests/README.md)",
   "loc.description": "Распределенный запуск тестов с помощью нескольких агентов тестирования в группе компьютеров лаборатории",
   "loc.instanceNameFormat": "Выполнить тесты $(sourcefilters) для $(testMachineGroup)",
   "loc.group.displayName.testMachineGroups": "Группа тестовых машин",

--- a/Tasks/RunDistributedTests/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/RunDistributedTests/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "使用测试代理的 Visual Studio 测试",
-  "loc.helpMarkDown": "对实验室计算机组使用多个测试代理以分布方式运行测试",
+  "loc.helpMarkDown": "[详细信息](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/RunDistributedTests/README.md)",
   "loc.description": "对实验室计算机组使用多个测试代理以分布方式运行测试",
   "loc.instanceNameFormat": "在 $(testMachineGroup) 上运行测试 $(sourcefilters)",
   "loc.group.displayName.testMachineGroups": "测试计算机组",

--- a/Tasks/RunDistributedTests/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/RunDistributedTests/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "使用 Test Agent 執行 Visual Studio 測試",
-  "loc.helpMarkDown": "在實驗室電腦群組中使用多個測試代理程式來分散執行測試",
+  "loc.helpMarkDown": "[詳細資訊](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/RunDistributedTests/README.md)",
   "loc.description": "在實驗室電腦群組中使用多個測試代理程式來分散執行測試",
   "loc.instanceNameFormat": "在 $(testMachineGroup) 執行測試 $(sourcefilters) ",
   "loc.group.displayName.testMachineGroups": "測試電腦群組",

--- a/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/de-de/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Dateikopiervorgang auf Windows-Computer",
-  "loc.helpMarkDown": "Dateien auf Remotecomputer kopieren",
+  "loc.helpMarkDown": "[Weitere Informationen](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/WindowsMachineFileCopy/README.md)",
   "loc.description": "Dateien auf Remotecomputer kopieren",
   "loc.instanceNameFormat": "Dateien nach $(EnvironmentName) kopieren",
   "loc.group.displayName.advanced": "Erweitert",

--- a/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/es-es/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Copia de archivo en equipo Windows",
-  "loc.helpMarkDown": "Copiar archivos en equipo(s) remoto(s)",
+  "loc.helpMarkDown": "[Más información](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/WindowsMachineFileCopy/README.md)",
   "loc.description": "Copiar archivos en equipo(s) remoto(s)",
   "loc.instanceNameFormat": "Copiar archivos en $(EnvironmentName)",
   "loc.group.displayName.advanced": "Avanzado",

--- a/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/fr-fr/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Copie des fichiers de l'ordinateur Windows",
-  "loc.helpMarkDown": "Copier les fichiers sur les ordinateurs distants",
+  "loc.helpMarkDown": "[Plus d'informations](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/WindowsMachineFileCopy/README.md)",
   "loc.description": "Copier les fichiers sur les ordinateurs distants",
   "loc.instanceNameFormat": "Copier les fichiers sur $(EnvironmentName)",
   "loc.group.displayName.advanced": "Avancé",

--- a/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Copia dei file del computer Windows",
-  "loc.helpMarkDown": "Consente di copiare file nei computer remoti",
+  "loc.helpMarkDown": "[Altre informazioni](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/WindowsMachineFileCopy/README.md)",
   "loc.description": "Consente di copiare file nei computer remoti",
   "loc.instanceNameFormat": "Copia file in $(EnvironmentName)",
   "loc.group.displayName.advanced": "Avanzate",

--- a/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/ja-jp/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Windows コンピューターのファイル コピー",
-  "loc.helpMarkDown": "ファイルをリモート コンピューター (複数可) にコピーします",
+  "loc.helpMarkDown": "[詳細](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/WindowsMachineFileCopy/README.md)",
   "loc.description": "ファイルをリモート コンピューター (複数可) にコピーします",
   "loc.instanceNameFormat": "ファイルのコピー先 $(EnvironmentName)",
   "loc.group.displayName.advanced": "詳細設定",

--- a/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Windows 컴퓨터 파일 복사",
-  "loc.helpMarkDown": "파일을 원격 컴퓨터에 복사",
+  "loc.helpMarkDown": "[자세한 정보](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/WindowsMachineFileCopy/README.md)",
   "loc.description": "파일을 원격 컴퓨터에 복사",
   "loc.instanceNameFormat": "파일을 $(EnvironmentName)에 복사",
   "loc.group.displayName.advanced": "고급",

--- a/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Копирование файлов на компьютер Windows",
-  "loc.helpMarkDown": "Копировать файлы на удаленные компьютеры",
+  "loc.helpMarkDown": "[Подробнее](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/WindowsMachineFileCopy/README.md)",
   "loc.description": "Копировать файлы на удаленные компьютеры",
   "loc.instanceNameFormat": "Копировать файлы в $(EnvironmentName)",
   "loc.group.displayName.advanced": "Дополнительно",

--- a/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Windows 计算机文件复制",
-  "loc.helpMarkDown": "将文件复制到远程计算机",
+  "loc.helpMarkDown": "[详细信息](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/WindowsMachineFileCopy/README.md)",
   "loc.description": "将文件复制到远程计算机",
   "loc.instanceNameFormat": "将文件复制到 $(EnvironmentName)",
   "loc.group.displayName.advanced": "高级",

--- a/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/WindowsMachineFileCopy/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Windows 電腦檔案複製",
-  "loc.helpMarkDown": "複製檔案到遠端電腦",
+  "loc.helpMarkDown": "[詳細資訊](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/WindowsMachineFileCopy/README.md)",
   "loc.description": "複製檔案到遠端電腦",
   "loc.instanceNameFormat": "複製檔案到 $(EnvironmentName)",
   "loc.group.displayName.advanced": "進階",


### PR DESCRIPTION
Fixing helpmarkdown string in all DTL/DTA tasks to correctly contain More Information url which got updated in the original english task.json