### PR TITLE
Adding option to specify JDK path for Ant and Gradle tasks

### DIFF
--- a/Tasks/ANT/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ANT/Strings/resources.resjson/en-US/resources.resjson
@@ -16,8 +16,12 @@
   "loc.input.help.publishJUnitResults": "Select this option to publish JUnit Test results produced by the Ant build to VSO/TFS. Each test result file matching `Test Results Files` will be published as a test run in VSO/TFS.",
   "loc.input.label.testResultsFiles": "Test Results Files",
   "loc.input.help.testResultsFiles": "Test results files path.  Wildcards can be used.  For example, `**/TEST-*.xml` for all xml files whose name starts with TEST-.",
+  "loc.input.label.javaHomeSelection": "Set JAVA_HOME by",
+  "loc.input.help.javaHomeSelection": "Sets JAVA_HOME either by selecting a JDK version that will be discovered during builds or by manually entering a JDK path.",
   "loc.input.label.jdkVersion": "JDK Version",
   "loc.input.help.jdkVersion": "Will attempt to discover the path to the selected JDK version and set JAVA_HOME accordingly.",
+  "loc.input.label.jdkUserInputPath": "JDK Path",
+  "loc.input.help.jdkUserInputPath": "Sets JAVA_HOME to the given path.",
   "loc.input.label.jdkArchitecture": "JDK Architecture",
   "loc.input.help.jdkArchitecture": "Optionally supply the architecture (x86, x64) of JDK."
 }

--- a/Tasks/ANT/ant.ps1
+++ b/Tasks/ANT/ant.ps1
@@ -4,8 +4,10 @@
     [string]$targets,
     [string]$publishJUnitResults,   
     [string]$testResultsFiles, 
+    [string]$javaHomeSelection,
     [string]$jdkVersion,
-    [string]$jdkArchitecture
+    [string]$jdkArchitecture,
+    [string]$jdkUserInputPath
 )
 
 Write-Verbose 'Entering Ant.ps1'
@@ -14,8 +16,10 @@ Write-Verbose "options = $options"
 Write-Verbose "targets = $targets"
 Write-Verbose "publishJUnitResults = $publishJUnitResults"
 Write-Verbose "testResultsFiles = $testResultsFiles"
+Write-Verbose "javaHomeSelection = $javaHomeSelection"
 Write-Verbose "jdkVersion = $jdkVersion"
 Write-Verbose "jdkArchitecture = $jdkArchitecture"
+Write-Verbose "jdkUserInputPath = $jdkUserInputPath"
 
 #Verify Ant build file is specified
 if(!$antBuildFile)
@@ -28,14 +32,37 @@ import-module "Microsoft.TeamFoundation.DistributedTask.Task.Internal"
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.TestResults"
 
-if($jdkVersion -and $jdkVersion -ne "default")
+# If JAVA_HOME is being set by choosing a JDK version find the path to that specified version else use the path given by the user
+$jdkPath = $null
+if($javaHomeSelection -eq 'JDKVersion')
 {
-    $jdkPath = Get-JavaDevelopmentKitPath -Version $jdkVersion -Arch $jdkArchitecture
-    if (!$jdkPath) 
+    Write-Verbose "Using JDK version to find and set JAVA_HOME"
+    # If the JDK version is not the default set the jdkPath to the new JDK version selected
+    if($jdkVersion -and ($jdkVersion -ne "default"))
+     {
+        $jdkPath = Get-JavaDevelopmentKitPath -Version $jdkVersion -Arch $jdkArchitecture
+        if (!$jdkPath) 
+        {
+            throw (Get-LocalizedString -Key 'Could not find JDK {0} {1}. Please make sure the selected JDK is installed properly.' -ArgumentList $jdkVersion, $jdkArchitecture)
+        }
+     }
+}
+else
+{
+    Write-Verbose "Using path from user input to set JAVA_HOME"
+    if($jdkUserInputPath -and (Test-Path -LiteralPath $jdkUserInputPath))
     {
-        throw "Could not find JDK $jdkVersion $jdkArchitecture, please make sure the selected JDK is installed properly."
+        $jdkPath = $jdkUserInputPath
     }
-
+    else
+    {
+         throw (Get-LocalizedString -Key "The specified JDK path does not exist. Please provide a valid path.")
+    }
+}
+ 
+# If jdkPath is set to something other than the default then update JAVA_HOME
+if ($jdkPath)
+{
     Write-Host "Setting JAVA_HOME to $jdkPath"
     $env:JAVA_HOME = $jdkPath
     Write-Verbose "JAVA_HOME set to $env:JAVA_HOME"

--- a/Tasks/ANT/ant2.js
+++ b/Tasks/ANT/ant2.js
@@ -13,22 +13,36 @@ antb.arg(tl.getPathInput('antBuildFile', true, true));
 antb.arg(tl.getDelimitedInput('options', ' ', false));
 antb.arg(tl.getDelimitedInput('targets', ' ', false));
 
-// update JAVA_HOME if user selected specific JDK version
-var jdkVersion = tl.getInput('jdkVersion');
-var jdkArchitecture = tl.getInput('jdkArchitecture');
-if(jdkVersion != 'default') {
-  // jdkVersion should be in the form of 1.7, 1.8, or 1.10
-  // jdkArchitecture is either x64 or x86
-  // envName for version 1.7 and x64 would be "JAVA_HOME_7_X64"
-  var envName = "JAVA_HOME_" + jdkVersion.slice(2) + "_" + jdkArchitecture.toUpperCase();
-  var specifiedJavaHome = tl.getVariable(envName);
-  if (!specifiedJavaHome) {
-    tl.error('Failed to find specified JDK version.  Please make sure environment variable ' + envName + ' exists and is set to a valid JDK.');
-    tl.exit(1);    
-   }
+// update JAVA_HOME if user selected specific JDK version or set path manually
+var javaHomeSelection = tl.getInput('javaHomeSelection', true);
+var specifiedJavaHome = null;
+ 
+if (javaHomeSelection == 'JDKVersion') {
+        tl.debug('Using JDK version to find and set JAVA_HOME');
+        var jdkVersion = tl.getInput('jdkVersion');
+        var jdkArchitecture = tl.getInput('jdkArchitecture');
+    
+        if(jdkVersion != 'default') {
+              // jdkVersion should be in the form of 1.7, 1.8, or 1.10
+              // jdkArchitecture is either x64 or x86
+              // envName for version 1.7 and x64 would be "JAVA_HOME_7_X64"
+              var envName = "JAVA_HOME_" + jdkVersion.slice(2) + "_" + jdkArchitecture.toUpperCase();
+              specifiedJavaHome = tl.getVariable(envName);
+              if (!specifiedJavaHome) {
+                    tl.error('Failed to find specified JDK version. Please make sure environment variable ' + envName + ' exists and is set to the location of a corresponding JDK.');
+                    tl.exit(1);    
+              }
+        }
+}
+else {
+    tl.debug('Using path from user input to set JAVA_HOME');
+    var jdkUserInputPath = tl.getPathInput('jdkUserInputPath', true, true);
+    specifiedJavaHome = jdkUserInputPath;
+}
 
-   tl.debug('Set JAVA_HOME to ' + specifiedJavaHome);
-   process.env['JAVA_HOME'] = specifiedJavaHome;
+if (specifiedJavaHome) {
+    tl.debug('Set JAVA_HOME to ' + specifiedJavaHome);
+    process.env['JAVA_HOME'] = specifiedJavaHome;
 }
 
 var publishJUnitResults = tl.getInput('publishJUnitResults');

--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 9
+        "Patch": 10
     },
     "demands" : [
         "ant"
@@ -70,7 +70,20 @@
             "required": true,
             "groupName":"junitTestResults",
             "helpMarkDown": "Test results files path.  Wildcards can be used.  For example, `**/TEST-*.xml` for all xml files whose name starts with TEST-."
-        },            
+        },   
+        {
+             "name":"javaHomeSelection",
+             "type":"radio",
+             "label":"Set JAVA_HOME by",
+             "required":true,
+             "groupName":"advanced",
+             "defaultValue":"JDKVersion",
+             "helpMarkDown": "Sets JAVA_HOME either by selecting a JDK version that will be discovered during builds or by manually entering a JDK path.",
+             "options": {
+                "JDKVersion":"JDK Version",
+                "Path":"Path"
+            }
+        },        
         {
             "name":"jdkVersion",
             "type":"pickList",
@@ -79,12 +92,23 @@
             "groupName":"advanced",
             "defaultValue":"default",
             "helpMarkDown": "Will attempt to discover the path to the selected JDK version and set JAVA_HOME accordingly.",
+            "visibleRule":"javaHomeSelection = JDKVersion",
             "options": {
                 "default":"default",
                 "1.8":"JDK 8",
                 "1.7":"JDK 7",
                 "1.6":"JDK 6"
             }
+        },
+        {
+            "name":"jdkUserInputPath",
+            "type":"string",
+            "label":"JDK Path",
+            "required":true,
+            "groupName":"advanced",
+            "defaultValue":"",
+            "helpMarkDown": "Sets JAVA_HOME to the given path.",
+            "visibleRule":"javaHomeSelection = Path"
         },
         { 
             "name": "jdkArchitecture", 

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 9
+    "Patch": 10
   },
   "demands": [
     "ant"
@@ -76,6 +76,19 @@
       "helpMarkDown": "ms-resource:loc.input.help.testResultsFiles"
     },
     {
+      "name": "javaHomeSelection",
+      "type": "radio",
+      "label": "ms-resource:loc.input.label.javaHomeSelection",
+      "required": true,
+      "groupName": "advanced",
+      "defaultValue": "JDKVersion",
+      "helpMarkDown": "ms-resource:loc.input.help.javaHomeSelection",
+      "options": {
+        "JDKVersion": "JDK Version",
+        "Path": "Path"
+      }
+    },
+    {
       "name": "jdkVersion",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.jdkVersion",
@@ -83,12 +96,23 @@
       "groupName": "advanced",
       "defaultValue": "default",
       "helpMarkDown": "ms-resource:loc.input.help.jdkVersion",
+      "visibleRule": "javaHomeSelection = JDKVersion",
       "options": {
         "default": "default",
         "1.8": "JDK 8",
         "1.7": "JDK 7",
         "1.6": "JDK 6"
       }
+    },
+    {
+      "name": "jdkUserInputPath",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.jdkUserInputPath",
+      "required": true,
+      "groupName": "advanced",
+      "defaultValue": "",
+      "helpMarkDown": "ms-resource:loc.input.help.jdkUserInputPath",
+      "visibleRule": "javaHomeSelection = Path"
     },
     {
       "name": "jdkArchitecture",

--- a/Tasks/Gradle/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Gradle/Strings/resources.resjson/en-US/resources.resjson
@@ -18,8 +18,12 @@
   "loc.input.help.publishJUnitResults": "Select this option to publish JUnit Test results produced by the Gradle build to VSO/TFS. Each test result file matching `Test Results Files` will be published as a test run in VSO/TFS.",
   "loc.input.label.testResultsFiles": "Test Results Files",
   "loc.input.help.testResultsFiles": "Test results files path.  Wildcards can be used.  For example, `**/TEST-*.xml` for all xml files whose name starts with TEST-.",
+  "loc.input.label.javaHomeSelection": "Set JAVA_HOME by",
+  "loc.input.help.javaHomeSelection": "Sets JAVA_HOME either by selecting a JDK version that will be discovered during builds or by manually entering a JDK path.",
   "loc.input.label.jdkVersion": "JDK Version",
   "loc.input.help.jdkVersion": "Will attempt to discover the path to the selected JDK version and set JAVA_HOME accordingly.",
+  "loc.input.label.jdkUserInputPath": "JDK Path",
+  "loc.input.help.jdkUserInputPath": "Sets JAVA_HOME to the given path.",
   "loc.input.label.jdkArchitecture": "JDK Architecture",
   "loc.input.help.jdkArchitecture": "Optionally supply the architecture (x86, x64) of JDK."
 }

--- a/Tasks/Gradle/gradle2.js
+++ b/Tasks/Gradle/gradle2.js
@@ -17,22 +17,36 @@ var gb = new tl.ToolRunner(wrapperScript);
 gb.arg(tl.getDelimitedInput('options', ' ', false));
 gb.arg(tl.getDelimitedInput('tasks', ' ', true));
 
-// update JAVA_HOME if user selected specific JDK version
-var jdkVersion = tl.getInput('jdkVersion');
-var jdkArchitecture = tl.getInput('jdkArchitecture');
-if(jdkVersion != 'default') {
-  // jdkVersion should be in the form of 1.7, 1.8, or 1.10
-  // jdkArchitecture is either x64 or x86
-  // envName for version 1.7 and x64 would be "JAVA_HOME_7_X64"
-  var envName = "JAVA_HOME_" + jdkVersion.slice(2) + "_" + jdkArchitecture.toUpperCase();
-  var specifiedJavaHome = tl.getVariable(envName);
-  if (!specifiedJavaHome) {
-    tl.error('Failed to find specified JDK version.  Please make sure environment varialbe ' + envName + ' exists and is set to a valid JDK.');
-    tl.exit(1);    
-   }
+// update JAVA_HOME if user selected specific JDK version or set path manually
+var javaHomeSelection = tl.getInput('javaHomeSelection', true);
+var specifiedJavaHome = null;
 
-   tl.debug('Set JAVA_HOME to ' + specifiedJavaHome);
-   process.env['JAVA_HOME'] = specifiedJavaHome;
+if (javaHomeSelection == 'JDKVersion') {
+        tl.debug('Using JDK version to find and set JAVA_HOME');
+        var jdkVersion = tl.getInput('jdkVersion');
+        var jdkArchitecture = tl.getInput('jdkArchitecture');
+    
+        if(jdkVersion != 'default') {
+              // jdkVersion should be in the form of 1.7, 1.8, or 1.10
+              // jdkArchitecture is either x64 or x86
+              // envName for version 1.7 and x64 would be "JAVA_HOME_7_X64"
+              var envName = "JAVA_HOME_" + jdkVersion.slice(2) + "_" + jdkArchitecture.toUpperCase();
+              specifiedJavaHome = tl.getVariable(envName);
+              if (!specifiedJavaHome) {
+                    tl.error('Failed to find specified JDK version. Please make sure environment variable ' + envName + ' exists and is set to the location of a corresponding JDK.');
+                    tl.exit(1);    
+              }
+        }
+}
+else {
+    tl.debug('Using path from user input to set JAVA_HOME');
+    var jdkUserInputPath = tl.getPathInput('jdkUserInputPath', true, true);  
+    specifiedJavaHome = jdkUserInputPath;
+}
+
+if (specifiedJavaHome) {
+        tl.debug('Set JAVA_HOME to ' + specifiedJavaHome);
+        process.env['JAVA_HOME'] = specifiedJavaHome;
 }
 
 var publishJUnitResults = tl.getInput('publishJUnitResults');

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 7
+        "Patch": 8
     },
     "demands" : [
         "java"
@@ -81,6 +81,19 @@
             "helpMarkDown": "Test results files path.  Wildcards can be used.  For example, `**/TEST-*.xml` for all xml files whose name starts with TEST-."
         },
         {
+            "name":"javaHomeSelection",
+            "type":"radio",
+            "label":"Set JAVA_HOME by",
+            "required":true,
+            "groupName":"advanced",
+            "defaultValue":"JDKVersion",
+            "helpMarkDown": "Sets JAVA_HOME either by selecting a JDK version that will be discovered during builds or by manually entering a JDK path.",
+            "options": {
+                "JDKVersion":"JDK Version",
+                "Path":"Path"
+            }
+        }, 
+        {
             "name":"jdkVersion",
             "type":"pickList",
             "label":"JDK Version",
@@ -88,12 +101,23 @@
             "groupName":"advanced",
             "defaultValue":"default",
             "helpMarkDown": "Will attempt to discover the path to the selected JDK version and set JAVA_HOME accordingly.",
+            "visibleRule":"javaHomeSelection = JDKVersion",
             "options": {
                 "default":"default",
                 "1.8":"JDK 8",
                 "1.7":"JDK 7",
                 "1.6":"JDK 6"
             }
+        },
+        {
+            "name":"jdkUserInputPath",
+            "type":"string",
+            "label":"JDK Path",
+            "required":true,
+            "groupName":"advanced",
+            "defaultValue":"",
+            "helpMarkDown": "Sets JAVA_HOME to the given path.",
+            "visibleRule":"javaHomeSelection = Path"
         },
         { 
             "name": "jdkArchitecture", 

--- a/Tasks/Gradle/task.loc.json
+++ b/Tasks/Gradle/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 7
+    "Patch": 8
   },
   "demands": [
     "java"
@@ -84,6 +84,19 @@
       "helpMarkDown": "ms-resource:loc.input.help.testResultsFiles"
     },
     {
+      "name": "javaHomeSelection",
+      "type": "radio",
+      "label": "ms-resource:loc.input.label.javaHomeSelection",
+      "required": true,
+      "groupName": "advanced",
+      "defaultValue": "JDKVersion",
+      "helpMarkDown": "ms-resource:loc.input.help.javaHomeSelection",
+      "options": {
+        "JDKVersion": "JDK Version",
+        "Path": "Path"
+      }
+    },
+    {
       "name": "jdkVersion",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.jdkVersion",
@@ -91,12 +104,23 @@
       "groupName": "advanced",
       "defaultValue": "default",
       "helpMarkDown": "ms-resource:loc.input.help.jdkVersion",
+      "visibleRule": "javaHomeSelection = JDKVersion",
       "options": {
         "default": "default",
         "1.8": "JDK 8",
         "1.7": "JDK 7",
         "1.6": "JDK 6"
       }
+    },
+    {
+      "name": "jdkUserInputPath",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.jdkUserInputPath",
+      "required": true,
+      "groupName": "advanced",
+      "defaultValue": "",
+      "helpMarkDown": "ms-resource:loc.input.help.jdkUserInputPath",
+      "visibleRule": "javaHomeSelection = Path"
     },
     {
       "name": "jdkArchitecture",

--- a/Tasks/Maven/maven2.js
+++ b/Tasks/Maven/maven2.js
@@ -35,8 +35,7 @@ if (javaHomeSelection == 'JDKVersion') {
 }
 else {
     tl.debug('Using path from user input to set JAVA_HOME');
-    var jdkUserInputPath = tl.getInput('jdkUserInputPath', true);   
-    tl.checkPath(jdkUserInputPath, 'JDK Path');
+    var jdkUserInputPath = tl.getPathInput('jdkUserInputPath', true, true);
     specifiedJavaHome = jdkUserInputPath;
 }
 


### PR DESCRIPTION
Building off of PR https://github.com/Microsoft/vso-agent-tasks/pull/440 which added the ability for users to specify the path of the JDK they wanted to use. That change was just for the Maven task but this change is for both Ant and Gradle tasks. Again I did the same testing as I did for the Maven changes. 