### PR TITLE
Trim tfs collection url

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
@@ -455,9 +455,9 @@ function CanSkipTestAgentConfiguration
         }
     }
 
-    if ($TfsCollection -ne $existingConfiguration.TfsCollection)
+    if ($TfsCollection.Trim("/") -ne $existingConfiguration.TfsCollection.Trim("/"))
     {
-        Write-Verbose -Message ("Tfs Collection Url mismatch. Expected : {0}, Current {1}. Reconfiguration required." -f $TfsCollection, $existingConfiguration.TfsCollection) -Verbose
+        Write-Verbose -Message ("Tfs Collection Url mismatch. Expected : {0}, Current {1}. Reconfiguration required." -f $TfsCollection.Trim("/"), $existingConfiguration.TfsCollection.Trim("/")) -Verbose
         return $false
     }
 


### PR DESCRIPTION
Bug 414912 : Machine gets stuck in infinite reboot if used in RM and agent is configured as process

Problem :
In some cases, (clear repro not available), machine goes into an infinite reboot state. Observed that this happened only when agent is configured as process and in RM scenario.

Root Cause :
From the logs, it was found that in RM the tfs collection url contains an extra slash at the end. However TA tries to match the collection url without the slash, because of this after every reboot, testagent configuration keeps happening.

Fix :
Before comparing collection urls, trim the slashes.

Testing :
Ran a basic end to end to in RM.
Fabrikam fiber in Build