### PR TITLE
Add link in hint for additional arguments of NuGet tasks

### DIFF
--- a/Tasks/NugetPackager/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/NugetPackager/Strings/resources.resjson/en-US/resources.resjson
@@ -16,7 +16,7 @@
   "loc.input.label.configurationToPack": "Configuration to Package",
   "loc.input.help.configurationToPack": "When using a csproj file this specifies the configuration to package",
   "loc.input.label.nuGetAdditionalArgs": "NuGet Arguments",
-  "loc.input.help.nuGetAdditionalArgs": "Additional arguments passed to NuGet.exe pack ",
+  "loc.input.help.nuGetAdditionalArgs": "Additional arguments passed to NuGet.exe pack. [More Information](https://docs.nuget.org/consume/command-line-reference#user-content-pack-command).",
   "loc.input.label.nuGetPath": "Path to NuGet.exe",
   "loc.input.help.nuGetPath": "Optionally supply the path to NuGet.exe"
 }

--- a/Tasks/NugetPackager/task.json
+++ b/Tasks/NugetPackager/task.json
@@ -60,7 +60,7 @@
             "label": "NuGet Arguments",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Additional arguments passed to NuGet.exe pack ",
+            "helpMarkDown": "Additional arguments passed to NuGet.exe pack. [More Information](https://docs.nuget.org/consume/command-line-reference#user-content-pack-command).",
             "groupName": "advanced"
         },
         {

--- a/Tasks/NugetPublisher/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/NugetPublisher/Strings/resources.resjson/en-US/resources.resjson
@@ -12,7 +12,7 @@
   "loc.input.label.connectedServiceName": "Nuget Server Endpoint",
   "loc.input.help.connectedServiceName": "The nuget server generic endpoint, set the key 'Password/Token Key' field to your nuget api key",
   "loc.input.label.nuGetAdditionalArgs": "NuGet Arguments",
-  "loc.input.help.nuGetAdditionalArgs": "Additional arguments passed to NuGet.exe pack ",
+  "loc.input.help.nuGetAdditionalArgs": "Additional arguments passed to NuGet.exe push. [More Information](https://docs.nuget.org/consume/command-line-reference#user-content-push-command).",
   "loc.input.label.nuGetPath": "Path to NuGet.exe",
   "loc.input.help.nuGetPath": "Optionally supply the path to NuGet.exe"
 }

--- a/Tasks/NugetPublisher/task.json
+++ b/Tasks/NugetPublisher/task.json
@@ -42,7 +42,7 @@
             "label": "NuGet Arguments",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Additional arguments passed to NuGet.exe pack ",
+            "helpMarkDown": "Additional arguments passed to NuGet.exe push. [More Information](https://docs.nuget.org/consume/command-line-reference#user-content-push-command).",
             "groupName": "advanced"
         },
         {


### PR DESCRIPTION
Fix help for NuGet publishing task additional arguments and add Additional Info link to hint for additional arguments of NuGet publishing and pack task