### PR TITLE
Task:418942 Fix insufficient error message when wrong username and password are provided in DeployTestAgent Task

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
@@ -831,7 +831,7 @@ function InvokeTestAgentConfigExe([string[]] $Arguments, [string] $Version, [Sys
         $stderr = $p.StandardError.ReadToEnd()
 
         Write-Verbose -Message ("Stdout : {0}" -f $stdout) -Verbose
-        Write-Warning -Message ("Stderr : {0}" -f $stderr)
+        Write-Warning -Message ("Stderr : {0}" -f $stderr) -Verbose
         Write-Verbose -Message ("Exit code : {0}" -f $p.ExitCode) -Verbose
 
         $out = @{

--- a/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentConfiguration.ps1
@@ -831,7 +831,7 @@ function InvokeTestAgentConfigExe([string[]] $Arguments, [string] $Version, [Sys
         $stderr = $p.StandardError.ReadToEnd()
 
         Write-Verbose -Message ("Stdout : {0}" -f $stdout) -Verbose
-        Write-Warning -Message ("Stderr : {0}" -f $stderr) -Verbose
+        Write-Verbose -Message ("Stderr : {0}" -f $stderr) -Verbose
         Write-Verbose -Message ("Exit code : {0}" -f $p.ExitCode) -Verbose
 
         $out = @{

--- a/Tasks/DeployVisualStudioTestAgent/TestAgentInstall.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/TestAgentInstall.ps1
@@ -34,7 +34,7 @@ function Install-Product($SetupPath, $UserName, $Password, $ProductVersion, $Arg
 		}
 		catch
 		{
-			Write-Warning -Verbose "Caught exception while installing Test Agent"
+			Write-Verbose -Verbose "Caught exception while installing Test Agent"
 			throw $_.Exception
 		}
                  
@@ -50,20 +50,20 @@ function Install-Product($SetupPath, $UserName, $Password, $ProductVersion, $Arg
 					# delete the file which indicated that test agent installation failed.
 					remove-item $testAgentFile -force | Out-Null
 					# we have retried once .Now fail with appropriate message
-					Write-Warning -Verbose "Retried to install Test Agent"
+					Write-Verbose -Verbose "Retried to install Test Agent"
 					throw ("The return code {0} was not expected during installation of Test Agent. Check the installation logs for more details." -f $exitCode.ToString())
 				}
 				else
 				{
 					#creating testagent file to indicate testagent installation failed.
 					New-Item -Path $testAgentFile -type File | Out-Null
-					Write-Warning -Message ("Installation of Test Agent failed with Error code {0}. Retrying once by rebooting machine" -f $exitCode.ToString()) -Verbose
+					Write-Verbose -Message ("Installation of Test Agent failed with Error code {0}. Retrying once by rebooting machine" -f $exitCode.ToString()) -Verbose
 					return 3010;
 				}
 			}
 			catch
 			{
-				Write-Warning -Verbose "Error occured while retrying the Test Agent installation"
+				Write-Verbose -Verbose "Error occured while retrying the Test Agent installation"
 				throw ("The return code {0} was not expected during installation of Test Agent. Check the installation logs for more details." -f $exitCode.ToString())
 			}
 		}

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 13
+        "Patch": 14
     },
     "demands": [
 

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 13
+    "Patch": 14
   },
   "demands": [],
   "minimumAgentVersion": "1.88.0",


### PR DESCRIPTION
Problem: Currently in the Visual Studio Test Agent Deployment, if a user provides wrong credentials (username and password) while configuring the task, "Configure Agent" step fails without printing proper error message. This was because Write-Warning cmdlets are not getting printed on the console.

Fix: Changed the Write-Warning cmdlets to Write-Verbose

Testing Done: Manual validation