### PR TITLE
Changing test assembly input type.

### DIFF
--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 17
+    "Patch": 18
   },
   "demands": [
     "vstest"
@@ -29,7 +29,7 @@
   "inputs": [
     {
       "name": "testAssembly",
-      "type": "filePath",
+      "type": "string",
       "label": "Test Assembly",
       "defaultValue": "**\\*test*.dll;-:**\\obj\\**",
       "required": true,

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 17
+    "Patch": 18
   },
   "demands": [
     "vstest"
@@ -32,7 +32,7 @@
   "inputs": [
     {
       "name": "testAssembly",
-      "type": "filePath",
+      "type": "string",
       "label": "ms-resource:loc.input.label.testAssembly",
       "defaultValue": "**\\*test*.dll;-:**\\obj\\**",
       "required": true,


### PR DESCRIPTION
Fix for Bug 329867:Its confusing for VSTest task to accept source filter as file path, when the actual value supported is only a regex based string