### PR TITLE
bugs:  419917, 419922, 

### DIFF
--- a/Tasks/ANTPreview/ant.ps1
+++ b/Tasks/ANTPreview/ant.ps1
@@ -122,12 +122,14 @@ if($isCoverageEnabled)
    
    if(Test-Path $summaryFile)
    {
+		Write-Verbose "Summary file = $summaryFile" -Verbose
+		Write-Verbose "Report directory = $reportDirectory" -Verbose
 		Write-Verbose "Calling Publish-CodeCoverage" -Verbose
 		Publish-CodeCoverage -CodeCoverageTool $codeCoverageTool -SummaryFileLocation $summaryFile -ReportDirectory $reportDirectory -Context $distributedTaskContext    
    }
    else
    {
-		Write-Warning "No code coverage found to publish." -Verbose
+		Write-Warning "No code coverage found to publish. There might be a build failure resulting in no code coverage." -Verbose
    }
 }
 

--- a/Tasks/ANTPreview/ant.ps1
+++ b/Tasks/ANTPreview/ant.ps1
@@ -22,7 +22,7 @@ Write-Verbose "testResultsFiles = $testResultsFiles" -Verbose
 Write-Verbose "jdkVersion = $jdkVersion" -Verbose
 Write-Verbose "jdkArchitecture = $jdkArchitecture" -Verbose
 
-$isCoverageEnabled = !$codeCoverageTool.equals("NoCoverage")
+$isCoverageEnabled = !$codeCoverageTool.equals("None")
 if($isCoverageEnabled)
 {
     Write-Verbose "codeCoverageTool = $codeCoverageTool" -Verbose

--- a/Tasks/ANTPreview/task.json
+++ b/Tasks/ANTPreview/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 1
+        "Patch": 2
     },
     "demands" : [
         "ant"

--- a/Tasks/ANTPreview/task.loc.json
+++ b/Tasks/ANTPreview/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "ant"

--- a/Tasks/GradlePreview/Gradle.ps1
+++ b/Tasks/GradlePreview/Gradle.ps1
@@ -116,12 +116,14 @@ if($isCoverageEnabled)
 {
 	if(Test-Path $summaryFile)
 	{
+		Write-Verbose "Summary file = $summaryFile" -Verbose
+		Write-Verbose "Report directory = $reportDirectory" -Verbose
 		Write-Verbose "Calling Publish-CodeCoverage" -Verbose
 		Publish-CodeCoverage -CodeCoverageTool $codeCoverageTool -SummaryFileLocation $summaryFile -ReportDirectory $reportDirectory -Context $distributedTaskContext   
 	}
 	else
 	{
-		Write-Warning "No code coverage found to publish." -Verbose
+		Write-Warning "No code coverage found to publish. There might be a build failure resulting in no code coverage." -Verbose
 	}   
 }
 

--- a/Tasks/GradlePreview/Gradle.ps1
+++ b/Tasks/GradlePreview/Gradle.ps1
@@ -78,7 +78,7 @@ $buildFile = Join-Path $buildRootPath "build.gradle"
 if($isCoverageEnabled)
 {
    # Enable code coverage in build file
-   Enable-CodeCoverage -BuildTool 'Gradle' -BuildFile $buildFile -CodeCoverageTool $codeCoverageTool -ClassFilter $classFilter -ClassFilesDirectory $classFilesDirectory -SummaryFile $summaryFileName -ReportDirectory $reportDirectoryName
+   Enable-CodeCoverage -BuildTool 'Gradle' -BuildFile $buildFile -CodeCoverageTool $codeCoverageTool -ClassFilter $classFilter -ClassFilesDirectory $classFilesDirectory -SummaryFile $summaryFileName -ReportDirectory $reportDirectoryName -ErrorAction Stop
    Write-Verbose "Code coverage is successfully enabled." -Verbose
 }
 else
@@ -114,8 +114,15 @@ else
 # check if code coverage has been enabled
 if($isCoverageEnabled)
 {
-   Write-Verbose "Calling Publish-CodeCoverage" -Verbose
-   Publish-CodeCoverage -CodeCoverageTool $codeCoverageTool -SummaryFileLocation $summaryFile -ReportDirectory $reportDirectory -Context $distributedTaskContext    
+	if(Test-Path $summaryFile)
+	{
+		Write-Verbose "Calling Publish-CodeCoverage" -Verbose
+		Publish-CodeCoverage -CodeCoverageTool $codeCoverageTool -SummaryFileLocation $summaryFile -ReportDirectory $reportDirectory -Context $distributedTaskContext   
+	}
+	else
+	{
+		Write-Warning "No code coverage found to publish." -Verbose
+	}   
 }
 
 Write-Verbose "Leaving script Gradle.ps1" -Verbose

--- a/Tasks/GradlePreview/task.json
+++ b/Tasks/GradlePreview/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 2
+        "Patch": 3
     },
     "demands" : [
         "java"

--- a/Tasks/GradlePreview/task.loc.json
+++ b/Tasks/GradlePreview/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "java"

--- a/Tasks/MavenPreview/maven.ps1
+++ b/Tasks/MavenPreview/maven.ps1
@@ -114,12 +114,14 @@ if($isCoverageEnabled)
    
    if(Test-Path $summaryFile)
    {
+		Write-Verbose "Summary file = $summaryFile" -Verbose
+		Write-Verbose "Report directory = $reportDirectory" -Verbose
 		Write-Verbose "Calling Publish-CodeCoverage" -Verbose
 		Publish-CodeCoverage -CodeCoverageTool $codeCoverageTool -SummaryFileLocation $summaryFile -ReportDirectory $reportDirectory -Context $distributedTaskContext    
    }
    else
    {
-		Write-Warning "No code coverage found to publish." -Verbose
+		Write-Warning "No code coverage found to publish. There might be a build failure resulting in no code coverage." -Verbose
    }
 }
 

--- a/Tasks/MavenPreview/task.json
+++ b/Tasks/MavenPreview/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "demands" : [
         "maven"

--- a/Tasks/MavenPreview/task.loc.json
+++ b/Tasks/MavenPreview/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "maven"


### PR DESCRIPTION
Bug 419917:When builld fails in ant it shouldnt call report code coverage in ant, maven and gradle cc tasks
Fix: set errorActionPreference to stop for enable code coverage. Made a check for availability of coverage.xml before trying to publish. Gave a help message saying" build might have failed. Fix build to get code coverage" .

Bug 419922:[Ant CC] When there is a test in the build.xml and when we dont execute it , We throw the exception saying jacococexec1.exec not found.

Used try and catch to avoid build from failing. Gave an warning message saying "There might be no tests"

