### PR TITLE
fix for Bug 422546

### DIFF
--- a/Tasks/ANTPreview/task.json
+++ b/Tasks/ANTPreview/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 2
+        "Patch": 3
     },
     "demands" : [
         "ant"
@@ -89,7 +89,7 @@
             "defaultValue": "None",
             "helpMarkDown": "Select the code coverage tool. Please make sure jacocoant.jar is available in lib folder of Ant installation.",
             "options": {
-                "NoCoverage": "None",
+                "None": "None",
                 "JaCoCo": "JaCoCo"
             }
         },

--- a/Tasks/ANTPreview/task.loc.json
+++ b/Tasks/ANTPreview/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "ant"
@@ -92,7 +92,7 @@
       "defaultValue": "None",
       "helpMarkDown": "ms-resource:loc.input.help.codeCoverageTool",
       "options": {
-        "NoCoverage": "None",
+        "None": "None",
         "JaCoCo": "JaCoCo"
       }
     },

--- a/Tasks/GradlePreview/task.json
+++ b/Tasks/GradlePreview/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 3
+        "Patch": 4
     },
     "demands" : [
         "java"
@@ -98,7 +98,7 @@
             "defaultValue": "None",
             "helpMarkDown": "Select the code coverage tool.",
             "options": {
-                "NoCoverage": "None",
+                "None": "None",
                 "JaCoCo": "JaCoCo"
             }
         },

--- a/Tasks/GradlePreview/task.loc.json
+++ b/Tasks/GradlePreview/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 3
+    "Patch": 4
   },
   "demands": [
     "java"
@@ -101,7 +101,7 @@
       "defaultValue": "None",
       "helpMarkDown": "ms-resource:loc.input.help.codeCoverageTool",
       "options": {
-        "NoCoverage": "None",
+        "None": "None",
         "JaCoCo": "JaCoCo"
       }
     },

--- a/Tasks/MavenPreview/task.json
+++ b/Tasks/MavenPreview/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 2
+        "Patch": 3
     },
     "demands" : [
         "maven"
@@ -89,7 +89,7 @@
             "defaultValue": "None",
             "helpMarkDown": "Select the code coverage tool.",
             "options": {
-                "NoCoverage": "None",
+                "None": "None",
                 "JaCoCo": "JaCoCo"
             }
         },

--- a/Tasks/MavenPreview/task.loc.json
+++ b/Tasks/MavenPreview/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "maven"
@@ -92,7 +92,7 @@
       "defaultValue": "None",
       "helpMarkDown": "ms-resource:loc.input.help.codeCoverageTool",
       "options": {
-        "NoCoverage": "None",
+        "None": "None",
         "JaCoCo": "JaCoCo"
       }
     },


### PR DESCRIPTION
While switching from jacoco to none the build fails saying coded coverage tool "NoCoverage" is  invalid.
Fix: changed the NOCoverage value to None 