### PR TITLE
Add new input to the NuGet pack task for build properties

### DIFF
--- a/Tasks/NugetPackager/NuGetPackager.ps1
+++ b/Tasks/NugetPackager/NuGetPackager.ps1
@@ -3,6 +3,7 @@ param(
     [string]$outputdir,
     [string]$versionByBuild,
     [string]$configurationToPack,
+    [string]$buildProperties,
     [string]$nuGetAdditionalArgs,
     [string]$nuGetPath
 )
@@ -105,7 +106,12 @@ foreach ($fileToPackage in $foundFiles)
     $slnFolder = $(Get-ItemProperty -Path $fileToPackage -Name 'DirectoryName').DirectoryName
     #Setup Nuget
     Write-Host "Creating Nuget Arguments:"
-    $argsPack = "pack $fileToPackage -OutputDirectory $outputdir -Properties Configuration=$configurationToPack";
+    $buildProps = "Configuration=$configurationToPack";
+    if ([string]::IsNullOrEmpty($buildProperties) -eq $false)
+    {
+        $buildProps = ($buildProps + ";" + $buildProperties)
+    }
+    $argsPack = "pack $fileToPackage -OutputDirectory $outputdir -Properties $buildProps";
     
     if ($b_versionByBuild)
     {

--- a/Tasks/NugetPackager/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/NugetPackager/Strings/resources.resjson/en-US/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.outputdir": "Folder where packages will be created, if empty will be created in the directory of csproj or nuspec file",
   "loc.input.label.configurationToPack": "Configuration to Package",
   "loc.input.help.configurationToPack": "When using a csproj file this specifies the configuration to package",
+  "loc.input.label.buildProperties": "Additional build properties",
+  "loc.input.help.buildProperties": "Semicolon delimited list of properties used to build the package.",
   "loc.input.label.nuGetAdditionalArgs": "NuGet Arguments",
   "loc.input.help.nuGetAdditionalArgs": "Additional arguments passed to NuGet.exe pack ",
   "loc.input.label.nuGetPath": "Path to NuGet.exe",

--- a/Tasks/NugetPackager/task.json
+++ b/Tasks/NugetPackager/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 54
+        "Patch": 55
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [
@@ -52,6 +52,15 @@
             "defaultValue":"Release",
             "helpMarkDown": "When using a csproj file this specifies the configuration to package",
             "required":false,
+            "groupName": "advanced"
+        },
+        {
+            "name": "buildProperties",
+            "type": "string",
+            "label": "Additional build properties",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Semicolon delimited list of properties used to build the package.",
             "groupName": "advanced"
         },
         {

--- a/Tasks/NugetPackager/task.loc.json
+++ b/Tasks/NugetPackager/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 54
+    "Patch": 55
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [
@@ -55,6 +55,15 @@
       "defaultValue": "Release",
       "helpMarkDown": "ms-resource:loc.input.help.configurationToPack",
       "required": false,
+      "groupName": "advanced"
+    },
+    {
+      "name": "buildProperties",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.buildProperties",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.buildProperties",
       "groupName": "advanced"
     },
     {


### PR DESCRIPTION
Add new input to the NuGet Packager task for allowing to use build properties. 

This fixes #529 