### PR TITLE
sonar report processed output file schema changes

### DIFF
--- a/Tasks/SonarQubePostTest/CodeAnalysisFilePathComputation.ps1
+++ b/Tasks/SonarQubePostTest/CodeAnalysisFilePathComputation.ps1
@@ -20,12 +20,12 @@ function IsComponentFormatValid($tokens)
 
     if (!$tokens)
     {
-        Write-Verbose -Verbose "IsComponentFormatValid: tokens is invalid"
+        Write-Verbose "IsComponentFormatValid: tokens is invalid"
         return $isFormatValid
     }
     if ($tokens.Count -ne 4) 
     {
-        Write-Verbose -Verbose "IsComponentFormatValid: component is not in expected format, token count is not equal to 4"
+        Write-Verbose "IsComponentFormatValid: component is not in expected format, token count is not equal to 4"
         return $isFormatValid
     }
 
@@ -35,7 +35,7 @@ function IsComponentFormatValid($tokens)
     $outGuid = New-Object -TypeName "System.Guid"
     if (![System.Guid]::TryParse($guidToken, [ref]$outGuid))
     {
-        Write-Verbose -Verbose "$guidToken is not a GUID"
+        Write-Verbose "$guidToken is not a GUID"
         return $isFormatValid
     }
 
@@ -49,7 +49,7 @@ function GetRelativeFilePath($component)
     if ($component -and $ComponentKeyAndRelativePathCache.ContainsKey($component))
     {
         $relativeFilePath = $ComponentKeyAndRelativePathCache[$component]
-        Write-Verbose -Verbose "GetRelativeFilePath: Found cached entry, returning data from cache, relativePath:$relativeFilePath"
+        Write-Verbose "GetRelativeFilePath: Found cached entry, returning data from cache, relativePath:$relativeFilePath"
 
         return $relativeFilePath
     }
@@ -65,16 +65,16 @@ function GetRelativeFilePath($component)
 
     #third token must be guid
     $guidToken = $tokens[2]
-    Write-Verbose -Verbose "GetRelativeFilePath: guidToken:$guidToken"
+    Write-Verbose "GetRelativeFilePath: guidToken:$guidToken"
 
     if (!$ProjectGuidAndFilePathMap.ContainsKey($guidToken))
     {
-        Write-Verbose -Verbose "GetRelativeFilePath: An entry for project guid $guidToken could not be found, check ProjectInfo.xml file"
+        Write-Verbose "GetRelativeFilePath: An entry for project guid $guidToken could not be found, check ProjectInfo.xml file"
         return $null
     }
     if (!$ComponentKeyAndPathMap.ContainsKey($component))
     {
-        Write-Verbose -Verbose "GetRelativeFilePath: An entry for component key $component could not be found, check sonar-report.json file"
+        Write-Verbose "GetRelativeFilePath: An entry for component key $component could not be found, check sonar-report.json file"
         return $null
     }
 
@@ -84,16 +84,16 @@ function GetRelativeFilePath($component)
     $finalFilePath = [System.IO.Path]::GetDirectoryName($projectPath)
     
     $finalFilePath = [System.IO.Path]::Combine($finalFilePath, $ComponentKeyAndPathMap[$component])
-    Write-Verbose -Verbose "GetRelativeFilePath: finalFilePath:$finalFilePath"
+    Write-Verbose "GetRelativeFilePath: finalFilePath:$finalFilePath"
 
     $repoLocalPath = Get-TaskVariable -Context $distributedTaskContext -Name "Build.Repository.LocalPath"
     if (!$repoLocalPath)
     {
-        Write-Verbose -Verbose "GetRelativeFilePath: Could not get task variable Build.Repository.LocalPath"
+        Write-Verbose "GetRelativeFilePath: Could not get task variable Build.Repository.LocalPath"
         return $null
     }
 
-    Write-Verbose -Verbose "GetRelativeFilePath: repoLocalPath:$repoLocalPath"
+    Write-Verbose "GetRelativeFilePath: repoLocalPath:$repoLocalPath"
 
     #this will remove from the file path, the part upto the repo name. 
     #e.g. finalFilePath=C:\Agent\_work\ef030e14\s\Mail2Bug\Main.cs and repoLocalPath=C:\Agent\_work\ef030e14\s
@@ -102,7 +102,7 @@ function GetRelativeFilePath($component)
 
     #Replace '\' with '/'. VSO expects file path like /Mail2Bug/Main.cs (\Mail2Bug\Main.cs does not work)
     $finalFilePath = $finalFilePath.ToString().Replace([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
-    Write-Verbose -Verbose "GetRelativeFilePath: Returning finalFilePath:$finalFilePath"
+    Write-Verbose "GetRelativeFilePath: Returning finalFilePath:$finalFilePath"
 
     #save data into cache so next time we don't have to compute
     $ComponentKeyAndRelativePathCache.Add($component, $finalFilePath)
@@ -159,13 +159,13 @@ function ProcessSonarCodeAnalysisReport
     
     #read sonar-report.json file as a json object
     $json = Get-Content -Raw $sonarReportFilePath | ConvertFrom-Json
-    Write-Verbose -Verbose "ProcessSonarCodeAnalysisReport: Total issues: $($json.issues.Count)"
+    Write-Verbose "ProcessSonarCodeAnalysisReport: Total issues: $($json.issues.Count)"
 
     ConstructComponentKeyAndPathMap $json
 
     # '@' makes sure the result set is returned as an array
     $newIssues = @($json.issues | Where {$_.isNew -eq $true})
-    Write-Verbose -Verbose "ProcessSonarCodeAnalysisReport: Total new issues: $($newIssues.Count)"
+    Write-Verbose "ProcessSonarCodeAnalysisReport: Total new issues: $($newIssues.Count)"
 
     if ($($newIssues.Count) -gt 0)
     {
@@ -201,7 +201,7 @@ function CreateProjectGuidAndPathMap
         
         if ([System.IO.File]::Exists($projectInfoFilePath))
         {
-            Write-Verbose -Verbose "CreateProjectGuidAndPathMap: Processing project info file: $projectInfoFilePath"
+            Write-Verbose "CreateProjectGuidAndPathMap: Processing project info file: $projectInfoFilePath"
             [xml]$xmlContent = Get-Content $projectInfoFilePath
 
             if ($xmlContent -and !$ProjectGuidAndFilePathMap.ContainsKey($xmlContent.ProjectInfo.ProjectGuid))
@@ -219,7 +219,7 @@ function GenerateCodeAnalysisReport
 
     Write-Host "Post-processing sonar analysis report..."
 
-    Write-Verbose -Verbose "GenerateCodeAnalysisReport: agentBuildDirectory=$agentBuildDirectory"
+    Write-Verbose "GenerateCodeAnalysisReport: agentBuildDirectory=$agentBuildDirectory"
 
     #bail out if sonar-report.json does not exist
     $sonarReportFilePath = GetSonarReportFilePath $agentBuildDirectory

--- a/Tasks/SonarQubePostTest/CodeAnalysisFilePathComputation.ps1
+++ b/Tasks/SonarQubePostTest/CodeAnalysisFilePathComputation.ps1
@@ -153,6 +153,9 @@ function ProcessSonarCodeAnalysisReport
 
     $sonarReportFilePath = GetSonarReportFilePath $agentBuildDirectory
     $sonarReportProcessedFilePath = GetSonarReportProcessedFilePath $agentBuildDirectory
+
+    $sonarReportProcessedRootObj = New-Object -TypeName PSObject
+    Add-Member -InputObject $sonarReportProcessedRootObj -MemberType NoteProperty -Name status -Value "Analysis Complete"
     
     #read sonar-report.json file as a json object
     $json = Get-Content -Raw $sonarReportFilePath | ConvertFrom-Json
@@ -173,10 +176,12 @@ function ProcessSonarCodeAnalysisReport
             #add a new property in json which stores the file path so it can be consumed directly
             Add-Member -InputObject $issue -MemberType NoteProperty -Name relativePath -Value $filePath
         }
-
-        #save the results into output file
-        $newIssues | ConvertTo-Json | Set-Content -Path $sonarReportProcessedFilePath
     }
+
+    Add-Member -InputObject $sonarReportProcessedRootObj -MemberType NoteProperty -Name issues -Value $newIssues
+
+    #save the results into output file
+    $sonarReportProcessedRootObj | ConvertTo-Json | Set-Content -Path $sonarReportProcessedFilePath
 }
 
 #creates a mapping of msbuild project guid and the path of .xxproj file on disk using ProjectInfo.xml file

--- a/Tasks/SonarQubePostTest/SonarQubePostTest.ps1
+++ b/Tasks/SonarQubePostTest/SonarQubePostTest.ps1
@@ -3,9 +3,8 @@ Write-Verbose "Starting SonarQube PostBuild Step"
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
 
 . ./SonarQubePostTestImpl.ps1
-. .\CodeAnalysisFilePathComputation.ps1
+. ./CodeAnalysisFilePathComputation.ps1
 
 InvokeMsBuildRunnerPostTest
 UploadSummaryMdReport
 HandleCodeAnalysisReporting
-


### PR DESCRIPTION
Minor changes in the sonar processed report schema. Earlier version was outputting an array of 'issue' objects. Newer version outputs a JSON object which has a 'status' key and 'issues' key. In earlier scenario, the processed report wasn't getting uploaded as build artifact if there were no new issues, in the current code the file gets uploaded as below: 
{
    "status":  "Analysis Complete",
    "issues":  [
               ]
}

This is useful in VSO to identify that the analysis was successful but no new issues were found.