### PR TITLE
Adding issues mode support in SonarQube build tasks

### DIFF
--- a/Tasks/SonarQubePostTest/CodeAnalysisFilePathComputation.ps1
+++ b/Tasks/SonarQubePostTest/CodeAnalysisFilePathComputation.ps1
@@ -154,9 +154,6 @@ function ProcessSonarCodeAnalysisReport
     $sonarReportFilePath = GetSonarReportFilePath $agentBuildDirectory
     $sonarReportProcessedFilePath = GetSonarReportProcessedFilePath $agentBuildDirectory
 
-    $sonarReportProcessedRootObj = New-Object -TypeName PSObject
-    Add-Member -InputObject $sonarReportProcessedRootObj -MemberType NoteProperty -Name status -Value "Analysis Complete"
-    
     #read sonar-report.json file as a json object
     $json = Get-Content -Raw $sonarReportFilePath | ConvertFrom-Json
     Write-Verbose "ProcessSonarCodeAnalysisReport: Total issues: $($json.issues.Count)"
@@ -178,6 +175,8 @@ function ProcessSonarCodeAnalysisReport
         }
     }
 
+    $sonarReportProcessedRootObj = New-Object -TypeName PSObject
+    Add-Member -InputObject $sonarReportProcessedRootObj -MemberType NoteProperty -Name status -Value "Analysis Complete"
     Add-Member -InputObject $sonarReportProcessedRootObj -MemberType NoteProperty -Name issues -Value $newIssues
 
     #save the results into output file

--- a/Tasks/SonarQubePreBuild/SonarQubePreBuild.ps1
+++ b/Tasks/SonarQubePreBuild/SonarQubePreBuild.ps1
@@ -24,11 +24,12 @@ import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
 . ./SonarQubePreBuildImpl.ps1
 
 
-$cmdLineArgs = UpdateArgsForPullRequestAnalysis $cmdLineArgs
-Write-Verbose -Verbose $cmdLineArgs
-
 $serviceEndpoint = GetEndpointData $connectedServiceName
 Write-Verbose "serverUrl = $($serviceEndpoint.Url)"
+
+$cmdLineArgs = UpdateArgsForPullRequestAnalysis $cmdLineArgs $serviceEndpoint
+Write-Verbose -Verbose $cmdLineArgs
+
 
 $currentDir = (Get-Item -Path ".\" -Verbose).FullName
 $bootstrapperDir = [System.IO.Path]::Combine($currentDir, "MSBuild.SonarQube.Runner-1.0.1") # the MSBuild.SonarQube.Runner is version specific

--- a/Tasks/SonarQubePreBuild/SonarQubePreBuild.ps1
+++ b/Tasks/SonarQubePreBuild/SonarQubePreBuild.ps1
@@ -30,7 +30,6 @@ Write-Verbose "serverUrl = $($serviceEndpoint.Url)"
 $cmdLineArgs = UpdateArgsForPullRequestAnalysis $cmdLineArgs $serviceEndpoint
 Write-Verbose -Verbose $cmdLineArgs
 
-
 $currentDir = (Get-Item -Path ".\" -Verbose).FullName
 $bootstrapperDir = [System.IO.Path]::Combine($currentDir, "MSBuild.SonarQube.Runner-1.0.1") # the MSBuild.SonarQube.Runner is version specific
 $bootstrapperPath = [System.IO.Path]::Combine($bootstrapperDir, "MSBuild.SonarQube.Runner.exe")

--- a/Tasks/SonarQubePreBuild/SonarQubePreBuildImpl.ps1
+++ b/Tasks/SonarQubePreBuild/SonarQubePreBuildImpl.ps1
@@ -92,16 +92,16 @@ function CreateCommandLineArgs
 
 function UpdateArgsForPullRequestAnalysis($cmdLineArgs, $serviceEndpoint)
 {
-	$prcaEnabled = GetTaskContextVariable "PullRequestSonarQubeCodeAnalysisEnabled"
-	if ($prcaEnabled -ieq "true")
-	{
-		if ($cmdLineArgs -and $cmdLineArgs.ToString().Contains("sonar.analysis.mode"))
-		{
-			throw "Error: sonar.analysis.mode seems to be set already. Please check the properties of SonarQube build tasks and try again."
-		}
+    $prcaEnabled = GetTaskContextVariable "PullRequestSonarQubeCodeAnalysisEnabled"
+    if ($prcaEnabled -ieq "true")
+    {
+        if ($cmdLineArgs -and $cmdLineArgs.ToString().Contains("sonar.analysis.mode"))
+        {
+            throw "Error: sonar.analysis.mode seems to be set already. Please check the properties of SonarQube build tasks and try again."
+        }
 
         $sqServerVersion = GetSonarQubeServerVersion $serviceEndpoint.Url $serviceEndpoint.Authorization.Parameters.UserName $serviceEndpoint.Authorization.Parameters.Password
-		Write-Verbose "PullRequestSonarQubeCodeAnalysisEnabled is true, setting command line args for sonar-runner. SonarQube version:$sqServerVersion"
+        Write-Verbose "PullRequestSonarQubeCodeAnalysisEnabled is true, setting command line args for sonar-runner. SonarQube version:$sqServerVersion"
 
         if (!$sqServerVersion)
         {
@@ -109,7 +109,7 @@ function UpdateArgsForPullRequestAnalysis($cmdLineArgs, $serviceEndpoint)
             throw "Error: Unable to fetch SonarQube server version. Please make sure SonarQube server is reachable at $($serviceEndpoint.Url)"
         }
 
-		$sqMajorVersion = GetSQMajorVersionNumber $sqServerVersion
+        $sqMajorVersion = GetSQMajorVersionNumber $sqServerVersion
         $sqMinorVersion = GetSQMinorVersionNumber $sqServerVersion
 
         #For SQ version 5.2+ use issues mode, otherwise use incremental mode. Incremntal mode is not supported in SQ 5.2+


### PR DESCRIPTION
These changes add support for issues mode in SonarQube build tasks. If SQ server version is greater than or equal to 5.2, we run analysis in 'issues' mode. For versions lower than 5.2, we run analysis in 'incremental' mode. SonarQube 5.2+ is going to remove support for incremental mode.