### PR TITLE
CsPkg, CsCfg & package task fields input are essentially artifact fil…

### DIFF
--- a/Tasks/AzureCloudPowerShellDeployment/task.json
+++ b/Tasks/AzureCloudPowerShellDeployment/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 15
+    "Patch": 16
   },
   "demands": [
     "azureps"
@@ -53,7 +53,7 @@
     },
     {
       "name": "CsPkg",
-      "type": "string",
+      "type": "artifactPath",
       "label": "CsPkg",
       "defaultValue": "",
       "required": true,
@@ -61,7 +61,7 @@
     },
     {
       "name": "CsCfg",
-      "type": "string",
+      "type": "artifactPath",
       "label": "CsCfg",
       "defaultValue": "",
       "required": true,

--- a/Tasks/AzureCloudPowerShellDeployment/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeployment/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 15
+    "Patch": 16
   },
   "demands": [
     "azureps"
@@ -56,7 +56,7 @@
     },
     {
       "name": "CsPkg",
-      "type": "string",
+      "type": "artifactPath",
       "label": "ms-resource:loc.input.label.CsPkg",
       "defaultValue": "",
       "required": true,
@@ -64,7 +64,7 @@
     },
     {
       "name": "CsCfg",
-      "type": "string",
+      "type": "artifactPath",
       "label": "ms-resource:loc.input.label.CsCfg",
       "defaultValue": "",
       "required": true,

--- a/Tasks/AzureWebPowerShellDeployment/task.json
+++ b/Tasks/AzureWebPowerShellDeployment/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 16
+    "Patch": 17
   },
   "demands": [
     "azureps"
@@ -71,7 +71,7 @@
     },
     {
       "name": "Package",
-      "type": "string",
+      "type": "artifactPath",
       "label": "Web Deploy Package",
       "defaultValue": "",
       "helpMarkDown": "Path to the Visual Studio Web Deploy package under the default artifact directory.",

--- a/Tasks/AzureWebPowerShellDeployment/task.loc.json
+++ b/Tasks/AzureWebPowerShellDeployment/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 16
+    "Patch": 17
   },
   "demands": [
     "azureps"
@@ -74,7 +74,7 @@
     },
     {
       "name": "Package",
-      "type": "string",
+      "type": "artifactPath",
       "label": "ms-resource:loc.input.label.Package",
       "defaultValue": "",
       "helpMarkDown": "ms-resource:loc.input.help.Package",


### PR DESCRIPTION
CsPkg, CsCfg & package task fields input are essentially artifact file paths.
We have task input type of filePath which maps to source repo. Adding a new task input type of artifactPath - which will be mapped to artifact file paths.