### PR TITLE
Fix: White-spaces within the repository-path result in an error

### DIFF
--- a/Tasks/NugetPackager/NuGetPackager.ps1
+++ b/Tasks/NugetPackager/NuGetPackager.ps1
@@ -98,7 +98,7 @@ $foundCount = $foundFiles.Count
 Write-Host "Found files: $foundCount"
 foreach ($fileToPackage in $foundFiles)
 {
-    Write-Host "--File: $fileToPackage"
+    Write-Host "--File: `"$fileToPackage`""
 }
 
 foreach ($fileToPackage in $foundFiles)
@@ -111,7 +111,7 @@ foreach ($fileToPackage in $foundFiles)
     {
         $buildProps = ($buildProps + ";" + $buildProperties)
     }
-    $argsPack = "pack $fileToPackage -OutputDirectory $outputdir -Properties $buildProps";
+    $argsPack = "pack `"$fileToPackage`" -OutputDirectory `"$outputdir`" -Properties $buildProps";
     
     if ($b_versionByBuild)
     {


### PR DESCRIPTION
Added quotes around parameters containing a file or directory path