### PR TITLE
Fix logging bug in NugetPublisher

### DIFF
--- a/Tasks/NugetPublisher/NuGetPublisher.ps1
+++ b/Tasks/NugetPublisher/NuGetPublisher.ps1
@@ -29,7 +29,7 @@ foreach($key in $PSBoundParameters.Keys)
 Write-Verbose "Importing modules"
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Internal"
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
-    
+
 
 #Setup Nuget
 Write-Host "Creating Nuget Arguments"
@@ -77,12 +77,12 @@ else
     Write-Host "No Pattern found in solution parameter."
     $packagesToPush = ,$searchPattern
 }
- 
-$foundCount = $packagesToPush.Count 
+
+$foundCount = $packagesToPush.Count
 Write-Host "Found files: $foundCount"
 foreach ($packageFile in $packagesToPush)
 {
-    Write-Host "File: $packagesToPush"
+    Write-Host "File: $packageFile"
 }
 
 foreach ($packageFile in $packagesToPush)
@@ -91,7 +91,7 @@ foreach ($packageFile in $packagesToPush)
     if($nuGetAdditionalArgs)
     {
         $argsUpload = ($argsUpload + " " + $nuGetAdditionalArgs);
-    } 
-    Write-Host "Invoking nuget with $argsUpload on $packageFile"  
-    Invoke-Tool -Path $nugetPath -Arguments "$argsUpload" 
+    }
+    Write-Host "Invoking nuget with $argsUpload on $packageFile"
+    Invoke-Tool -Path $nugetPath -Arguments "$argsUpload"
 }

--- a/Tasks/NugetPublisher/task.json
+++ b/Tasks/NugetPublisher/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 36
+        "Patch": 37
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [
@@ -18,7 +18,7 @@
             "displayName":"Advanced",
             "isExpanded":false
         }
-    ],    
+    ],
     "instanceNameFormat": "NuGet Publisher $(solution)",
     "inputs": [
         {


### PR DESCRIPTION
When printing out the list of found files, the entire array was being printed N times when the intent was to print each file individually.

Also removed some trailing whitespace from a few lines (automatically in VS Code).