### PR TITLE
Fix logging bug in NugetPublisher

### DIFF
--- a/Tasks/NugetPublisher/NuGetPublisher.ps1
+++ b/Tasks/NugetPublisher/NuGetPublisher.ps1
@@ -82,7 +82,7 @@ $foundCount = $packagesToPush.Count
 Write-Host "Found files: $foundCount"
 foreach ($packageFile in $packagesToPush)
 {
-    Write-Host "File: $packagesToPush"
+    Write-Host "File: $packageFile"
 }
 
 foreach ($packageFile in $packagesToPush)

--- a/Tasks/NugetPublisher/task.json
+++ b/Tasks/NugetPublisher/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 36
+        "Patch": 37
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/Tasks/NugetPublisher/task.loc.json
+++ b/Tasks/NugetPublisher/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 36
+    "Patch": 37
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [


### PR DESCRIPTION
When printing out the list of found files, the entire array was being printed N times when the intent was to print each file individually. Fix the code so that prints out the file instead of the entire array when iterating over the items in the array.