### PR TITLE
Fix https://jira.sonarsource.com/browse/TBSTFNP-23 - the username and…

### DIFF
--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 12
+        "Patch": 13
     },
     "minimumAgentVersion": "1.83.0",
     "instanceNameFormat": "Maven $(mavenPOMFile)",

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 12
+    "Patch": 13
   },
   "minimumAgentVersion": "1.83.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
… password fields in the endpoint JSON need to be read in a case-insensitive way. This is because the endpoint implementation seems to have changed. On discussing with the RM team they have recommended to use case-insensitive comparison. This is done by default on Windows.

