### PR TITLE
publishBuildArtifacts.js: Fix loop scope. Skip empty patterns.

### DIFF
--- a/Tasks/PublishBuildArtifacts/publishBuildArtifacts.js
+++ b/Tasks/PublishBuildArtifacts/publishBuildArtifacts.js
@@ -97,13 +97,16 @@ else {
         var map = {};
         for (var i = 0; i < contents.length; i++) {
             var pattern = contents[i].trim();
+            if (pattern.length == 0) {
+                continue;
+            }
             tl.debug('Matching ' + pattern);
             var realPattern = path.join(findRoot, pattern);
             tl.debug('Actual pattern: ' + realPattern);
             // in debug mode, output some match candidates
             tl.debug('Listing a few potential candidates...');
-            for (var i = 0; i < 10 && i < allFiles.length; i++) {
-                tl.debug('  ' + allFiles[i]);
+            for (var k = 0; k < 10 && k < allFiles.length; k++) {
+                tl.debug('  ' + allFiles[k]);
             }
             // let minimatch do the actual filtering
             var matches = tl.match(allFiles, realPattern, { matchBase: true });


### PR DESCRIPTION
Fix loop scope in publishBuildArtifacts.js. Skip empty patterns.