### PR TITLE
expose MsBuild.SonarQube.ProjectUri, if any of the following tasks needs it

### DIFF
--- a/Tasks/SonarQubePreBuild/SonarQubePreBuild.ps1
+++ b/Tasks/SonarQubePreBuild/SonarQubePreBuild.ps1
@@ -37,6 +37,8 @@ $bootstrapperPath = [System.IO.Path]::Combine($bootstrapperDir, "MSBuild.SonarQu
 # Set the path as context variable so that the post-test task will be able to read it and not compute it again;
 # Also, if the variable is not set, the post-test task will know that the pre-build task did not execute
 SetTaskContextVariable "MsBuild.SonarQube.BootstrapperPath" $bootstrapperPath
+# Expose MsBuild.SonarQube.ProjectUri, if any of the following tasks needs it
+SetTaskContextVariable "MsBuild.SonarQube.ProjectUri" "$($serviceEndpoint.Url)/dashboard/index?id=$($projectKey)"
 
 StoreSensitiveParametersInTaskContext $serviceEndpoint.Authorization.Parameters.UserName $serviceEndpoint.Authorization.Parameters.Password $dbUsername $dbPassword
 $arguments = CreateCommandLineArgs $projectKey $projectName $projectVersion $serviceEndpoint.Url $serviceEndpoint.Authorization.Parameters.UserName $serviceEndpoint.Authorization.Parameters.Password $dbUrl $dbUsername $dbPassword $cmdLineArgs $configFile

--- a/Tasks/SonarQubePreBuild/task.json
+++ b/Tasks/SonarQubePreBuild/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 28
+        "Patch": 29
     },
     "demands": [
         "msbuild",

--- a/Tasks/SonarQubePreBuild/task.loc.json
+++ b/Tasks/SonarQubePreBuild/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 28
+    "Patch": 29
   },
   "demands": [
     "msbuild",


### PR DESCRIPTION
The vso-online-tasks which follow the SonarQubePreBuild in the customer workflow should be able to get the URI of the project on the target SonarQube instance.

For example, think to a task which publishes artifacts whose quality indicators have been collected by means of the SonarQube plugin. It would be great to have the possibility to add, as metadata of the published atifacts, a link to the SonarQube project page.