### PR TITLE
Document command min agent version

### DIFF
--- a/docs/authoring/commands.md
+++ b/docs/authoring/commands.md
@@ -10,6 +10,7 @@ The general format for a logging command is:
             <th>Syntax</th>
             <th>Property Name</th>
             <th>Usage</th>
+            <th>Minimum Agent Version</th>
         </tr>
     </thead>
     <tbody>
@@ -35,6 +36,8 @@ The general format for a logging command is:
                     ##vso[task.logissue type=error;sourcepath=consoleapp/main.cs;linenumber=1;columnumber=1;code=100;]this is an error
                 </p>
             </td>
+            <td>
+            </td>
         </tr>
         <tr>
             <td>
@@ -54,6 +57,8 @@ The general format for a logging command is:
                     ##vso[task.setprogress value=75;]Upload Log
                 </p>
             </td>
+            <td>
+            </td>
         </tr>
         <tr>
             <td>
@@ -72,6 +77,8 @@ The general format for a logging command is:
                     Example: <br>
                     ##vso[task.complete result=Succeeded;]DONE
                 </p>
+            </td>
+            <td>
             </td>
         </tr>
         <tr>
@@ -107,6 +114,8 @@ The general format for a logging command is:
                     Update exist timeline record: ##vso[task.logdetail id=exist timeline record guid;progress=15;state=InProgress;]update timeline record
                 </p>
             </td>
+            <td>
+            </td>
         </tr>
         <tr>
             <td>
@@ -125,6 +134,8 @@ The general format for a logging command is:
                     Example: <br>
 					##vso[task.setvariable variable=testvar;]testvalue<br> 
                 </p>
+            </td>
+            <td>
             </td>
         </tr>
         <tr>
@@ -146,6 +157,8 @@ The general format for a logging command is:
 					##vso[task.addattachment type=myattachmenttype;name=myattachmentname;]c:\myattachment.txt<br> 
                 </p>
             </td>
+            <td>
+            </td>
         </tr>
     </tbody>
 </table>
@@ -158,6 +171,7 @@ The general format for a logging command is:
             <th>Syntax</th>
             <th>Property Name</th>
             <th>Usage</th>
+            <th>Minimum Agent Version</th>
         </tr>
     </thead>
     <tbody>
@@ -179,6 +193,8 @@ The general format for a logging command is:
                     ##vso[artifact.associate artifactname=drop;]#/1/build <br>
                 </p>
             </td>
+            <td>
+            </td>
         </tr>
         <tr>
             <td>
@@ -199,6 +215,8 @@ The general format for a logging command is:
                     ##vso[artifact.upload containerfolder=testresult;artifactname=uploadedresult;]c:\testresult.trx<br>
                 </p>
             </td>
+            <td>
+            </td>
     </tbody>
 </table>
 
@@ -210,6 +228,7 @@ The general format for a logging command is:
             <th>Syntax</th>
             <th>Property Name</th>
             <th>Usage</th>
+            <th>Minimum Agent Version</th>
         </tr>
     </thead>
     <tbody>
@@ -230,6 +249,8 @@ The general format for a logging command is:
                     ##vso[build.uploadlog]c:\msbuild.log
                 </p>
             </td>
+            <td>
+            </td>
         </tr>
         <tr>
             <td>
@@ -248,6 +269,8 @@ The general format for a logging command is:
                     ##vso[build.uploadsummary]c:\testsummary.md
                 </p>
             </td>
+            <td>
+            </td>
         </tr><tr>
             <td>
                 <p align="left">
@@ -264,6 +287,9 @@ The general format for a logging command is:
                     Example: <br>
                     ##vso[build.updatebuildnumber]my-new-build-number
                 </p>
+            </td>
+            <td>
+                1.88
             </td>
         </tr>
     </tbody>


### PR DESCRIPTION
Add a column for min agent version of individual logging commands. Add min agent version for `build.updatebuildnumber` as mentioned by @chrisrpatterson in https://github.com/Microsoft/vso-agent-tasks/issues/380#issuecomment-146878805