### PR TITLE
Adding Cobertura as an  option for Publishing Code Coverage Results

### DIFF
--- a/Tasks/PublishCodeCoverageResults/task.json
+++ b/Tasks/PublishCodeCoverageResults/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "demands" : [
     ],
@@ -28,7 +28,8 @@
             "defaultValue": "JaCoCo",
             "helpMarkDown": "Select the tool with which code coverage summary files have been generated",
             "options": {
-                "JaCoCo": "JaCoCo"
+                "JaCoCo": "JaCoCo",
+                "Cobertura": "Cobertura"
             }
         },
         {

--- a/Tasks/PublishCodeCoverageResults/task.loc.json
+++ b/Tasks/PublishCodeCoverageResults/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "1.88.0",
@@ -30,7 +30,8 @@
       "defaultValue": "JaCoCo",
       "helpMarkDown": "ms-resource:loc.input.help.codeCoverageTool",
       "options": {
-        "JaCoCo": "JaCoCo"
+        "JaCoCo": "JaCoCo",
+        "Cobertura": "Cobertura"
       }
     },
     {


### PR DESCRIPTION
Problem: There is not support for publishing Cobertura code coverage summary files in the PublishCodeCoverageTask today. This change adds support for that.

Fix: Adding Cobertura as an option in the supported tools drop down.

Testing Done: UTs and manual testing.