### PR TITLE
Avoid using 'Convert-String'…

### DIFF
--- a/Tasks/XamarinLicense/XamarinLicense.ps1
+++ b/Tasks/XamarinLicense/XamarinLicense.ps1
@@ -12,7 +12,7 @@ Write-Verbose "email = $email"
 Write-Verbose "activateAndroid = $activateAndroid"
 Write-Verbose "timeout = $timeout"
 
-$activateAndroidLicense = Convert-String $activateAndroid Boolean
+$activateAndroidLicense = [System.Convert]::ToBoolean($activateAndroid)
 Write-Verbose "activateAndroid (converted) = $activateAndroidLicense"
 
 # Import the Task.Common and Task.Internal dll that has all the cmdlets we need for Build


### PR DESCRIPTION
… since it's only available in Powershell 5.0, it's rather undocumented and I just cannot get `Convert-String "true" Boolean` to work on a freshly installed Windows 10 machine. Activating my Xamarin License constantly fails when building on my build server (it works on a hosted build server). This may not even be an issue with `Convert-String` in the first place, however, there must be ways to convert a string into a boolean pre-powershell-5.0 (and as far as I can tell, this is all what the call to `Convert-String` here is about).