### PR TITLE
Help text changes for Publish CC Task

### DIFF
--- a/Tasks/PublishCodeCoverageResults/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishCodeCoverageResults/Strings/resources.resjson/en-US/resources.resjson
@@ -9,9 +9,9 @@
   "loc.input.label.codeCoverageTool": "Code Coverage Tool",
   "loc.input.help.codeCoverageTool": "Select the tool with which code coverage summary files have been generated",
   "loc.input.label.summaryFileLocation": "Summary File",
-  "loc.input.help.summaryFileLocation": "Path of code coverage summary file, which has code coverage statistics like line, method, class coverage. For example, $(Build.Repository.LocalPath)\\jacoco\\jacoco.xml",
+  "loc.input.help.summaryFileLocation": "Path of code coverage summary file, which has code coverage statistics like line, method, class coverage. For example, $(Build.Repository.LocalPath)\\CodeCoverage\\Summary.xml",
   "loc.input.label.reportDirectory": "Report Directory",
-  "loc.input.help.reportDirectory": "Path of code coverage report directory. The report directory is published as an artifact against the build. For example, $(Build.Repository.LocalPath)\\jacoco",
+  "loc.input.help.reportDirectory": "Path of code coverage report directory. The report directory is published as an artifact against the build. For example, $(Build.Repository.LocalPath)\\CodeCoverageReport",
   "loc.input.label.additionalCodeCoverageFiles": "Additional Files",
   "loc.input.help.additionalCodeCoverageFiles": "Regular expression specifying the additional code coverage files to be published as an artifact against the build. For example, `$(Build.Repository.LocalPath)\\**\\*.exec`"
 }

--- a/Tasks/PublishCodeCoverageResults/task.json
+++ b/Tasks/PublishCodeCoverageResults/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "demands" : [
     ],
@@ -37,7 +37,7 @@
             "label": "Summary File",
             "defaultValue": "",
             "required": true,
-            "helpMarkDown": "Path of code coverage summary file, which has code coverage statistics like line, method, class coverage. For example, $(Build.Repository.LocalPath)\\jacoco\\jacoco.xml"
+            "helpMarkDown": "Path of code coverage summary file, which has code coverage statistics like line, method, class coverage. For example, $(Build.Repository.LocalPath)\\CodeCoverage\\Summary.xml"
         },
         {
             "name": "reportDirectory",
@@ -45,7 +45,7 @@
             "label": "Report Directory",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Path of code coverage report directory. The report directory is published as an artifact against the build. For example, $(Build.Repository.LocalPath)\\jacoco"
+            "helpMarkDown": "Path of code coverage report directory. The report directory is published as an artifact against the build. For example, $(Build.Repository.LocalPath)\\CodeCoverageReport"
         },
         {
             "name": "additionalCodeCoverageFiles",

--- a/Tasks/PublishCodeCoverageResults/task.loc.json
+++ b/Tasks/PublishCodeCoverageResults/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "minimumAgentVersion": "1.88.0",


### PR DESCRIPTION
Problem: The help texts for the fields in Publish CC Task are jacoco specific. The aim is to make them Cobertura-Jacoco neutral.

Solution: Required string changes have been made.

Testing: NA