### PR TITLE
leave the old command format for one more sprint, so we won't break c…

### DIFF
--- a/Tasks/PublishBuildArtifacts/publishBuildArtifacts.js
+++ b/Tasks/PublishBuildArtifacts/publishBuildArtifacts.js
@@ -97,16 +97,13 @@ else {
         var map = {};
         for (var i = 0; i < contents.length; i++) {
             var pattern = contents[i].trim();
-            if (pattern.length == 0) {
-                continue;
-            }
             tl.debug('Matching ' + pattern);
             var realPattern = path.join(findRoot, pattern);
             tl.debug('Actual pattern: ' + realPattern);
             // in debug mode, output some match candidates
             tl.debug('Listing a few potential candidates...');
-            for (var k = 0; k < 10 && k < allFiles.length; k++) {
-                tl.debug('  ' + allFiles[k]);
+            for (var i = 0; i < 10 && i < allFiles.length; i++) {
+                tl.debug('  ' + allFiles[i]);
             }
             // let minimatch do the actual filtering
             var matches = tl.match(allFiles, realPattern, { matchBase: true });
@@ -157,11 +154,13 @@ else {
             // upload or copy
             if (artifactType === "container") {
                 data["containerfolder"] = artifactName;
+                data["localpath"] = stagingFolder;
                 tl.command("artifact.upload", data, stagingFolder);
             }
             else if (artifactType === "filepath") {
                 tl.mkdirP(targetPath);
                 tl.cp("-Rf", stagingFolder, targetPath);
+                data["artifactlocation"] = targetPath;
                 tl.command("artifact.associate", data, targetPath);
             }
         }

--- a/Tasks/PublishBuildArtifacts/publishBuildArtifacts.ts
+++ b/Tasks/PublishBuildArtifacts/publishBuildArtifacts.ts
@@ -191,12 +191,14 @@ else {
             // upload or copy
             if (artifactType === "container") {
                 data["containerfolder"] = artifactName;
+                data["localpath"] = stagingFolder;
                 tl.command("artifact.upload", data, stagingFolder);
             }
             else if (artifactType === "filepath") {
                 tl.mkdirP(targetPath);
                 tl.cp("-Rf", stagingFolder, targetPath);
 
+                data["artifactlocation"] = targetPath;
                 tl.command("artifact.associate", data, targetPath);
             }
         }

--- a/Tasks/PublishBuildArtifacts/task.json
+++ b/Tasks/PublishBuildArtifacts/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 7
+    "Patch": 8
   },
   "demands": [
   ],

--- a/Tasks/PublishBuildArtifacts/task.loc.json
+++ b/Tasks/PublishBuildArtifacts/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 7
+    "Patch": 8
   },
   "demands": [],
   "minimumAgentVersion": "1.83.0",


### PR DESCRIPTION
leave the old command format for one more sprint, so we won't break compat between new task and old agent when task got updated.