### PR TITLE
Error when deploy Azure Web Site from on-prem agent

### DIFF
--- a/Tasks/AzureWebPowerShellDeployment/Publish-AzureWebDeployment.ps1
+++ b/Tasks/AzureWebPowerShellDeployment/Publish-AzureWebDeployment.ps1
@@ -48,7 +48,7 @@ Write-Host "Slot= $Slot"
 Write-Host "AdditionalArguments= $AdditionalArguments"
 
 #Find the package to deploy
-import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
+import-module "Microsoft.TeamFoundation.DistributedTask.Task.Deployment.Azure"
 
 Write-Host "packageFile= Find-Files -SearchPattern $Package"
 $packageFile = Find-Files -SearchPattern $Package


### PR DESCRIPTION
The term 'Initialize-AzurePowerShellSupport' is not recognized as the name of a cmdlet, function, script file, or operable program