### PR TITLE
* Changed $VersionRegex parameter value according to ability create n…

### DIFF
--- a/Tasks/NugetPackager/NuGetPackager.ps1
+++ b/Tasks/NugetPackager/NuGetPackager.ps1
@@ -26,7 +26,7 @@ if ($b_versionByBuild)
     
     # Regular expression pattern to find the version in the build number 
     # and then apply it to the assemblies
-    $VersionRegex = "\d+\.\d+\.\d+\.\d+"
+    $VersionRegex = "\d+\.\d+\.\d+(\.\d+)|(-[A-Za-z0-9]+)"
     
     # If this script is not running on a build server, remind user to 
     # set environment variables so that this script can be debugged


### PR DESCRIPTION
Changed $VersionRegex parameter value according to ability create prerelease Nuget packages. More at https://docs.nuget.org/create/versioning#prerelease-versions (NOT TESTED ON TFS. JUST REGEX TESTED)

This is my very first pull request. If I did something wrong, please, tell me.

Thanks a lot Petr