### PR TITLE
Pin to task.json for Ant Maven and Gradle tasks

### DIFF
--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 12
+        "Patch": 13
     },
     "demands" : [
         "ant"
@@ -181,7 +181,8 @@
         "PowerShell": {
             "target": "$(currentDirectory)\\ant.ps1",
             "argumentFormat": "",
-            "workingDirectory": "$(currentDirectory)"
+            "workingDirectory": "$(currentDirectory)",
+            "platforms" : ["windows"]
         }
     }
 }

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 12
+    "Patch": 13
   },
   "demands": [
     "ant"
@@ -185,7 +185,10 @@
     "PowerShell": {
       "target": "$(currentDirectory)\\ant.ps1",
       "argumentFormat": "",
-      "workingDirectory": "$(currentDirectory)"
+      "workingDirectory": "$(currentDirectory)",
+      "platforms": [
+        "windows"
+      ]
     }
   }
 }

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 10
+        "Patch": 11
     },
     "demands" : [
         "java"
@@ -176,7 +176,8 @@
         "PowerShell": {
             "target": "$(currentDirectory)\\gradle.ps1",
             "argumentFormat": "",
-            "workingDirectory": "$(currentDirectory)"
+            "workingDirectory": "$(currentDirectory)",
+            "platforms" : ["windows"]
         },
         "Node": {
             "target": "gradle2.js",

--- a/Tasks/Gradle/task.loc.json
+++ b/Tasks/Gradle/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 10
+    "Patch": 11
   },
   "demands": [
     "java"
@@ -179,7 +179,10 @@
     "PowerShell": {
       "target": "$(currentDirectory)\\gradle.ps1",
       "argumentFormat": "",
-      "workingDirectory": "$(currentDirectory)"
+      "workingDirectory": "$(currentDirectory)",
+      "platforms": [
+        "windows"
+      ]
     },
     "Node": {
       "target": "gradle2.js",

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 15
+        "Patch": 16
     },
    "minimumAgentVersion": "1.89.0",
     "instanceNameFormat": "Maven $(mavenPOMFile)",
@@ -241,7 +241,8 @@
         "PowerShell": {
             "target": "$(currentDirectory)\\maven.ps1",
             "argumentFormat": "",
-            "workingDirectory": "$(currentDirectory)"
+            "workingDirectory": "$(currentDirectory)",
+            "platforms" : ["windows"]
         }
     }
 }

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 15
+    "Patch": 16
   },
   "minimumAgentVersion": "1.89.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -244,7 +244,10 @@
     "PowerShell": {
       "target": "$(currentDirectory)\\maven.ps1",
       "argumentFormat": "",
-      "workingDirectory": "$(currentDirectory)"
+      "workingDirectory": "$(currentDirectory)",
+      "platforms": [
+        "windows"
+      ]
     }
   }
 }


### PR DESCRIPTION
Problem: With the addition of Node for xplat tasks, Ant, Maven and Gradle on windows agent are failing due to cmd compatibility issues. The task will work fine if the powershell script is executed.

Solution: Pinned the task to use powershell for windows agent.

Testing: Manual