### PR TITLE
making publishing to tfs as an option for vstest

### DIFF
--- a/Tasks/VsTest/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/VsTest/Strings/resources.resjson/en-US/resources.resjson
@@ -19,6 +19,8 @@
   "loc.input.help.runSettingsFile": "Path to runsettings file to use with the tests. Use $(Build.SourcesDirectory) to access the Project folder.",
   "loc.input.label.overrideTestrunParameters": "Override TestRun Parameters",
   "loc.input.help.overrideTestrunParameters": "Override parameters defined in the TestRunParameters section of runsettings file. For example: Platform=$(platform);Port=8080",
+  "loc.input.label.publishResultsEnabled": "Publish to VSO/TFS",
+  "loc.input.help.publishResultsEnabled": "Select this option to publish test results to VSO/TFS. Each test result file will be published as a test run in VSO/TFS.",
   "loc.input.label.codeCoverageEnabled": "Code Coverage Enabled",
   "loc.input.help.codeCoverageEnabled": "Collect code coverage information from the Test run.",
   "loc.input.label.vsTestVersion": "VSTest version",

--- a/Tasks/VsTest/VSTest.ps1
+++ b/Tasks/VsTest/VSTest.ps1
@@ -8,7 +8,8 @@ param(
     [string]$overrideTestrunParameters,
     [string]$otherConsoleOptions,
     [string]$platform,
-    [string]$configuration
+    [string]$configuration,
+    [string]$publishResultsEnabled
 )
 
 Write-Verbose "Entering script VSTestConsole.ps1"
@@ -74,14 +75,18 @@ if($testAssemblyFiles)
 
     $resultFiles = Find-Files -SearchPattern "*.trx" -RootFolder $testResultsDirectory 
 
-    if($resultFiles) 
+    $publishResultsOption = Convert-String $publishResultsEnabled Boolean
+    if($publishResultsOption) 
     {
-        Publish-TestResults -Context $distributedTaskContext -TestResultsFiles $resultFiles -TestRunner "VSTest" -Platform $platform -Configuration $configuration
-    }
-    else
-    {
-        Write-Host "##vso[task.logissue type=warning;code=002003;]"
-        Write-Warning "No results found to publish."
+        if($resultFiles)
+        {
+            Publish-TestResults -Context $distributedTaskContext -TestResultsFiles $resultFiles -TestRunner "VSTest" -Platform $platform -Configuration $configuration
+        }
+        else
+        {
+            Write-Host "##vso[task.logissue type=warning;code=002003;]"
+            Write-Warning "No results found to publish."
+        }
     }
 }
 else

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 23
+    "Patch": 24
   },
   "demands": [
     "vstest"
@@ -75,6 +75,14 @@
       "required": false,
       "helpMarkDown": "Override parameters defined in the TestRunParameters section of runsettings file. For example: Platform=$(platform);Port=8080"      
     },
+    {
+      "name": "publishResultsEnabled",
+      "type": "boolean",
+      "label": "Publish to VSO/TFS",
+      "defaultValue": "true",
+      "required": false,
+      "helpMarkDown": "Select this option to publish test results to VSO/TFS. Each test result file will be published as a test run in VSO/TFS."
+    }, 
     {
       "name": "codeCoverageEnabled",
       "type": "boolean",

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 23
+    "Patch": 24
   },
   "demands": [
     "vstest"
@@ -77,6 +77,14 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.overrideTestrunParameters"
+    },
+    {
+      "name": "publishResultsEnabled",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.publishResultsEnabled",
+      "defaultValue": "true",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.publishResultsEnabled"
     },
     {
       "name": "codeCoverageEnabled",


### PR DESCRIPTION
will help avoid publish in PR builds.