### PR TITLE
rewritten the multi module/single module gradle jacoco build/code cov…

### DIFF
--- a/Tasks/Gradle/Gradle.ps1
+++ b/Tasks/Gradle/Gradle.ps1
@@ -89,7 +89,8 @@ if ($jdkPath)
     Write-Verbose "JAVA_HOME set to $env:JAVA_HOME"
 }
 
-$buildRootPath = Split-Path $wrapperScript -Parent
+$buildRootPath = $cwd
+$wrapperDirectory = Split-Path $wrapperScript -Parent
 $reportDirectoryName = [guid]::NewGuid()
 $reportDirectory = Join-Path $buildRootPath $reportDirectoryName
 
@@ -98,11 +99,20 @@ $summaryFile = Join-Path $buildRootPath $reportDirectoryName
 $summaryFile = Join-Path $summaryFile $summaryFileName 
 $buildFile = Join-Path $buildRootPath "build.gradle"
 
+# check if project is multi module gradle build or not
+$subprojects = Invoke-BatchScript -Path $wrapperScript -Arguments 'properties' -WorkingFolder $buildRootPath | Select-String '^subprojects: (.*)'|ForEach-Object {$_.Matches[0].Groups[1].Value}
+Write-Verbose "subprojects: $subprojects"
+$singlemodule = [string]::IsNullOrEmpty($subprojects) -or $subprojects -eq '[]'
+
 # check if code coverage has been enabled
 if($isCoverageEnabled)
 {
+   #Write-Error "cwd $cwd" 
+   #Write-Error "build $buildFile"
+   #Write-Error "wrapper $wrapperScript"
+   #Write-Error "wsitem $wrapperScriptItem"
    # Enable code coverage in build file
-   Enable-CodeCoverage -BuildTool 'Gradle' -BuildFile $buildFile -CodeCoverageTool $codeCoverageTool -ClassFilter $classFilter -ClassFilesDirectories $classFilesDirectories -SummaryFile $summaryFileName -ReportDirectory $reportDirectoryName -ErrorAction Stop
+   Enable-CodeCoverage -BuildTool 'Gradle' -BuildFile $buildFile -CodeCoverageTool $codeCoverageTool -ClassFilter $classFilter -ClassFilesDirectories $classFilesDirectories -SummaryFile $summaryFileName -ReportDirectory $reportDirectoryName -SingleModule $singlemodule -ErrorAction Stop
    Write-Verbose "Code coverage is successfully enabled." -Verbose
 }
 else
@@ -110,7 +120,23 @@ else
     Write-Verbose "Option to enable code coverage was not selected and is being skipped." -Verbose
 }
 
-$arguments = "$options $tasks"
+
+if($isCoverageEnabled)
+{
+	if($singlemodule)
+	{
+		$arguments = "$options $tasks jacocoTestReport"
+	}
+	else
+	{
+		$arguments = "$options $tasks jacocoRootReport"
+	}
+}
+else
+{
+	$arguments = "$options $tasks"
+}
+
 Write-Verbose "Invoking Gradle wrapper $wrapperScript $arguments"
 Invoke-BatchScript -Path $wrapperScript -Arguments $arguments -WorkingFolder $cwd
 

--- a/Tasks/Gradle/Gradle.ps1
+++ b/Tasks/Gradle/Gradle.ps1
@@ -108,7 +108,7 @@ $singlemodule = [string]::IsNullOrEmpty($subprojects) -or $subprojects -eq '[]'
 if($isCoverageEnabled)
 {
    # Enable code coverage in build file
-   Enable-CodeCoverage -BuildTool 'Gradle' -BuildFile $buildFile -CodeCoverageTool $codeCoverageTool -ClassFilter $classFilter -ClassFilesDirectories $classFilesDirectories -SummaryFile $summaryFileName -ReportDirectory $reportDirectoryName -SingleModule $singlemodule -ErrorAction Stop
+   Enable-CodeCoverage -BuildTool 'Gradle' -BuildFile $buildFile -CodeCoverageTool $codeCoverageTool -ClassFilter $classFilter -ClassFilesDirectories $classFilesDirectories -SummaryFile $summaryFileName -ReportDirectory $reportDirectoryName -IsSingleModule $singlemodule -ErrorAction Stop
    Write-Verbose "Code coverage is successfully enabled." -Verbose
 }
 else

--- a/Tasks/Gradle/Gradle.ps1
+++ b/Tasks/Gradle/Gradle.ps1
@@ -107,10 +107,6 @@ $singlemodule = [string]::IsNullOrEmpty($subprojects) -or $subprojects -eq '[]'
 # check if code coverage has been enabled
 if($isCoverageEnabled)
 {
-   #Write-Error "cwd $cwd" 
-   #Write-Error "build $buildFile"
-   #Write-Error "wrapper $wrapperScript"
-   #Write-Error "wsitem $wrapperScriptItem"
    # Enable code coverage in build file
    Enable-CodeCoverage -BuildTool 'Gradle' -BuildFile $buildFile -CodeCoverageTool $codeCoverageTool -ClassFilter $classFilter -ClassFilesDirectories $classFilesDirectories -SummaryFile $summaryFileName -ReportDirectory $reportDirectoryName -SingleModule $singlemodule -ErrorAction Stop
    Write-Verbose "Code coverage is successfully enabled." -Verbose

--- a/Tasks/Gradle/Gradle.ps1
+++ b/Tasks/Gradle/Gradle.ps1
@@ -108,7 +108,7 @@ $singlemodule = [string]::IsNullOrEmpty($subprojects) -or $subprojects -eq '[]'
 if($isCoverageEnabled)
 {
    # Enable code coverage in build file
-   Enable-CodeCoverage -BuildTool 'Gradle' -BuildFile $buildFile -CodeCoverageTool $codeCoverageTool -ClassFilter $classFilter -ClassFilesDirectories $classFilesDirectories -SummaryFile $summaryFileName -ReportDirectory $reportDirectoryName -IsSingleModule $singlemodule -ErrorAction Stop
+   Enable-CodeCoverage -BuildTool 'Gradle' -BuildFile $buildFile -CodeCoverageTool $codeCoverageTool -ClassFilter $classFilter -ClassFilesDirectories $classFilesDirectories -SummaryFile $summaryFileName -ReportDirectory $reportDirectoryName -IsMultiModule !$singlemodule -ErrorAction Stop
    Write-Verbose "Code coverage is successfully enabled." -Verbose
 }
 else

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 13
+        "Patch": 14
     },
     "demands" : [
         "java"
@@ -80,7 +80,7 @@
             "name": "testResultsFiles",
             "type": "filePath",
             "label": "Test Results Files",
-            "defaultValue": "**/TEST-*.xml",
+            "defaultValue": "**/build/test-results/TEST-*.xml",
             "required": true,
             "groupName":"junitTestResults",
             "helpMarkDown": "Test results files path.  Wildcards can be used.  For example, `**/TEST-*.xml` for all xml files whose name starts with TEST-.",
@@ -103,7 +103,7 @@
             "name": "classFilesDirectories",
             "type": "string",
             "label": "Class Files Directories",
-            "defaultValue": "build/classes/main",
+            "defaultValue": "build/classes/main/",
             "required": true,
             "groupName": "codeCoverage",
             "helpMarkDown": "Comma separated list of directories containing class files, archive files(jar, war etc.). Directories and archives are searched recursively for class files. Code coverage is reported for class files present in the directories. For example, classes1/Tests,classes2/Tests2. Refer https://docs.gradle.org/current/userguide/jacoco_plugin.html.",

--- a/Tasks/Gradle/task.loc.json
+++ b/Tasks/Gradle/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 13
+    "Patch": 14
   },
   "demands": [
     "java"
@@ -83,7 +83,7 @@
       "name": "testResultsFiles",
       "type": "filePath",
       "label": "ms-resource:loc.input.label.testResultsFiles",
-      "defaultValue": "**/TEST-*.xml",
+      "defaultValue": "**/build/test-results/TEST-*.xml",
       "required": true,
       "groupName": "junitTestResults",
       "helpMarkDown": "ms-resource:loc.input.help.testResultsFiles",
@@ -106,7 +106,7 @@
       "name": "classFilesDirectories",
       "type": "string",
       "label": "ms-resource:loc.input.label.classFilesDirectories",
-      "defaultValue": "build/classes/main",
+      "defaultValue": "build/classes/main/",
       "required": true,
       "groupName": "codeCoverage",
       "helpMarkDown": "ms-resource:loc.input.help.classFilesDirectories",


### PR DESCRIPTION
Enable Jacoco Code coverage support for Gradle Multi Module and Single Module projects.
Fixed issues in Setting the right build paths for Gradle builds