### PR TITLE
Add gulp test command to run task unit tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,7 @@ var semver = require('semver');
 var Q = require('q');
 var exec = require('child_process').exec;
 var ts = require('gulp-typescript');
+var spawn = require('child_process').spawn;
 
 var _buildRoot = path.join(__dirname, '_build', 'Tasks');
 var _pkgRoot = path.join(__dirname, '_package');
@@ -19,25 +20,45 @@ var _oldPkg = path.join(__dirname, 'Package');
 var _wkRoot = path.join(__dirname, '_working');
 
 gulp.task('clean', function (cb) {
-	del([_buildRoot, _pkgRoot, _wkRoot, _oldPkg],cb);
+    del([_buildRoot, _pkgRoot, _wkRoot, _oldPkg],cb);
 });
 
 gulp.task('compile', function (cb) {
-	var tasksPath = path.join(__dirname, 'Tasks', '**/*.ts');
-	var tsResult = gulp.src([tasksPath, 'definitions/*.d.ts'])
-		.pipe(ts({
-		   declarationFiles: false,
-		   noExternalResolve: true,
-		   'module': 'commonjs'
-		}));
-		
-	return tsResult.js.pipe(gulp.dest(path.join(__dirname, 'Tasks')));
+    var tasksPath = path.join(__dirname, 'Tasks', '**/*.ts');
+    var tsResult = gulp.src([tasksPath, 'definitions/*.d.ts'])
+        .pipe(ts({
+           declarationFiles: false,
+           noExternalResolve: true,
+           'module': 'commonjs'
+        }));
+        
+    return tsResult.js.pipe(gulp.dest(path.join(__dirname, 'Tasks')));
 });
 
 gulp.task('build', ['clean', 'compile'], function () {
-	shell.mkdir('-p', _buildRoot);
-	return gulp.src(path.join(__dirname, 'Tasks', '**/task.json'))
+    shell.mkdir('-p', _buildRoot);
+    return gulp.src(path.join(__dirname, 'Tasks', '**/task.json'))
         .pipe(pkgm.PackageTask(_buildRoot));
+});
+
+gulp.task('test', ['pester']);
+
+gulp.task('pester', function (done) {
+    // Runs powershell unit tests based on pester
+    var pester = spawn('powershell.exe', ['-Command', 'Invoke-Pester -EnableExit -Path Tasks'], { stdio: 'inherit' });
+    pester.on('exit', function(code, signal) {
+        if (code != 0) {
+            done('Pester tests failed!');
+        }
+        else {
+            done();
+        }
+    });
+
+    pester.on('error', function(err) {
+        gutil.log('We may be in a non-windows machine or powershell.exe is not in path. Skip pester tests.');
+        done();
+    });
 });
 
 gulp.task('default', ['build']);
@@ -51,113 +72,113 @@ gulp.task('default', ['build']);
 //-----------------------------------------------------------------------------------------------------------------
 
 var QExec = function(commandLine) {
-	var defer = Q.defer();
+    var defer = Q.defer();
 
-	gutil.log('running: ' + commandLine)
-	var child = exec(commandLine, function(err, stdout, stderr) {
-		if (err) {
-			defer.reject(err);
-			return;
-		}
+    gutil.log('running: ' + commandLine)
+    var child = exec(commandLine, function(err, stdout, stderr) {
+        if (err) {
+            defer.reject(err);
+            return;
+        }
 
-		if (stdout) {
-			gutil.log(stdout);
-		}
+        if (stdout) {
+            gutil.log(stdout);
+        }
 
-		if (stderr) {
-			gutil.log(stderr);
-		}
+        if (stderr) {
+            gutil.log(stderr);
+        }
 
-		defer.resolve();
-	});
+        defer.resolve();
+    });
 
-	return defer.promise;
+    return defer.promise;
 }
 
 gulp.task('zip', ['build'], function(done) {
-	shell.mkdir('-p', _wkRoot);
-	var zipPath = path.join(_wkRoot, 'contents');
+    shell.mkdir('-p', _wkRoot);
+    var zipPath = path.join(_wkRoot, 'contents');
 
-	return gulp.src(path.join(_buildRoot, '**', '*'))
-	           .pipe(zip('Microsoft.TeamFoundation.Build.Tasks.zip'))	        
-	           .pipe(gulp.dest(zipPath));
+    return gulp.src(path.join(_buildRoot, '**', '*'))
+               .pipe(zip('Microsoft.TeamFoundation.Build.Tasks.zip'))            
+               .pipe(gulp.dest(zipPath));
 });
 
 //
 // gulp package --version 1.0.31 --server \\some\nuget\svr\path
 //
 gulp.task('package', ['zip'], function(done) {
-	var nugetPath = shell.which('nuget');
-	if (!nugetPath) {
-		done(new gutil.PluginError('PackageTask', 'nuget.exe needs to be in the path.  could not find.'));
-		return;
-	}
+    var nugetPath = shell.which('nuget');
+    if (!nugetPath) {
+        done(new gutil.PluginError('PackageTask', 'nuget.exe needs to be in the path.  could not find.'));
+        return;
+    }
 
-	var nuget3Path = shell.which('nuget3');
-	if (!nuget3Path) {
-		done(new gutil.PluginError('PackageTask', 'nuget3.exe needs to be in the path.  could not find.'));
-		return;
-	}
+    var nuget3Path = shell.which('nuget3');
+    if (!nuget3Path) {
+        done(new gutil.PluginError('PackageTask', 'nuget3.exe needs to be in the path.  could not find.'));
+        return;
+    }
 
-	var options = minimist(process.argv.slice(2), {});
-	var version = options.version;
-	if (!version) {
-		done(new gutil.PluginError('PackageTask', 'supply version with --version'));
-		return;		
-	}
+    var options = minimist(process.argv.slice(2), {});
+    var version = options.version;
+    if (!version) {
+        done(new gutil.PluginError('PackageTask', 'supply version with --version'));
+        return;        
+    }
 
-	if (!semver.valid(version)) {
-		done(new gutil.PluginError('PackageTask', 'invalid semver version: ' + version));
-		return;				
-	}	
+    if (!semver.valid(version)) {
+        done(new gutil.PluginError('PackageTask', 'invalid semver version: ' + version));
+        return;                
+    }    
 
-	var server = options.server;
+    var server = options.server;
 
-	shell.mkdir('-p', _pkgRoot);
-	
-	var pkgName = 'Mseng.MS.TF.Build.Tasks';
+    shell.mkdir('-p', _pkgRoot);
+    
+    var pkgName = 'Mseng.MS.TF.Build.Tasks';
 
-	gutil.log('Generating .nuspec file');
-	var contents = '<?xml version="1.0" encoding="utf-8"?>' + os.EOL;
-		contents += '<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">' + os.EOL;
-        contents += '   <metadata>' + os.EOL;
-        contents += '      <id>' + pkgName + '</id>' + os.EOL;
-        contents += '      <version>' + version + '</version>' + os.EOL;
-        contents += '      <authors>bigbldt</authors>' + os.EOL;
-        contents += '      <owners>bigbldt,Microsoft</owners>' + os.EOL;
-        contents += '      <requireLicenseAcceptance>false</requireLicenseAcceptance>' + os.EOL;
-        contents += '      <description>For VSS internal use only</description>' + os.EOL;
-        contents += '      <tags>VSSInternal</tags>' + os.EOL;
-    	contents += '   </metadata>' + os.EOL;
-		contents += '</package>' + os.EOL;
+    gutil.log('Generating .nuspec file');
+    var contents = '<?xml version="1.0" encoding="utf-8"?>' + os.EOL;
+    contents += '<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">' + os.EOL;
+    contents += '   <metadata>' + os.EOL;
+    contents += '      <id>' + pkgName + '</id>' + os.EOL;
+    contents += '      <version>' + version + '</version>' + os.EOL;
+    contents += '      <authors>bigbldt</authors>' + os.EOL;
+    contents += '      <owners>bigbldt,Microsoft</owners>' + os.EOL;
+    contents += '      <requireLicenseAcceptance>false</requireLicenseAcceptance>' + os.EOL;
+    contents += '      <description>For VSS internal use only</description>' + os.EOL;
+    contents += '      <tags>VSSInternal</tags>' + os.EOL;
+    contents += '   </metadata>' + os.EOL;
+    contents += '</package>' + os.EOL;
 
-	var nuspecPath = path.join(_wkRoot, pkgName + '.nuspec');
-	fs.writeFile(nuspecPath, contents, function(err) {
-		if (err) {
-			done(new gutil.PluginError('PackageTask', err.message));
-			return;
-		}
+    var nuspecPath = path.join(_wkRoot, pkgName + '.nuspec');
+    fs.writeFile(nuspecPath, contents, function(err) {
+        if (err) {
+            done(new gutil.PluginError('PackageTask', err.message));
+            return;
+        }
 
-		var cmdline = '"' + nugetPath + '" pack ' + nuspecPath + ' -OutputDirectory ' + _pkgRoot;
-		QExec(cmdline)
-		.then(function() {
-			// publish only if version and source supplied - used by CI server that does official publish
-			if (server) {
-				var pkgLocation = path.join(_pkgRoot, pkgName + '.' + version + '.nupkg');
-				var cmdline = '"' + nuget3Path + '" push ' + pkgLocation + ' -Source ' + server + ' -apikey Skyrise';
-				return QExec(cmdline);				
-			}
-			else {
-				return;
-			}
+        var cmdline = '"' + nugetPath + '" pack ' + nuspecPath + ' -OutputDirectory ' + _pkgRoot;
+        QExec(cmdline)
+        .then(function() {
+            // publish only if version and source supplied - used by CI server that does official publish
+            if (server) {
+                var pkgLocation = path.join(_pkgRoot, pkgName + '.' + version + '.nupkg');
+                var cmdline = '"' + nuget3Path + '" push ' + pkgLocation + ' -Source ' + server + ' -apikey Skyrise';
+                return QExec(cmdline);                
+            }
+            else {
+                return;
+            }
 
-		})
-		.then(function() {
-			done();
-		})
-		.fail(function(err) {
-			done(new gutil.PluginError('PackageTask', err.message));
-		})
-		
-	});
+        })
+        .then(function() {
+            done();
+        })
+        .fail(function(err) {
+            done(new gutil.PluginError('PackageTask', err.message));
+        })
+        
+    });
 });

--- a/package.js
+++ b/package.js
@@ -15,33 +15,33 @@ _banner += '// GENERATED FILE - DO NOT EDIT DIRECTLY' + os.EOL;
 _banner += _divider;
 
 var createError = function(msg) {
-	return new gutil.PluginError('PackageTask', msg);
+    return new gutil.PluginError('PackageTask', msg);
 }
 
 var validate = function(folderName, task) {
-	var defer = Q.defer();
+    var defer = Q.defer();
 
-	var vn = (task.name  || folderName);
+    var vn = (task.name  || folderName);
 
-	if (!task.id || !check.isUUID(task.id)) {
-		defer.reject(createError(vn + ': id is a required guid'));
-	};
+    if (!task.id || !check.isUUID(task.id)) {
+        defer.reject(createError(vn + ': id is a required guid'));
+    };
 
-	if (!task.name || !check.isAlphanumeric(task.name)) {
-		defer.reject(createError(vn + ': name is a required alphanumeric string'));
-	}
+    if (!task.name || !check.isAlphanumeric(task.name)) {
+        defer.reject(createError(vn + ': name is a required alphanumeric string'));
+    }
 
-	if (!task.friendlyName || !check.isLength(task.friendlyName, 1, 40)) {
-		defer.reject(createError(vn + ': friendlyName is a required string <= 40 chars'));
-	}
+    if (!task.friendlyName || !check.isLength(task.friendlyName, 1, 40)) {
+        defer.reject(createError(vn + ': friendlyName is a required string <= 40 chars'));
+    }
 
-	if (!task.instanceNameFormat) {
-		defer.reject(createError(vn + ': instanceNameFormat is required'));	
-	}
+    if (!task.instanceNameFormat) {
+        defer.reject(createError(vn + ': instanceNameFormat is required'));
+    }
 
-	// resolve if not already rejected
-	defer.resolve();
-	return defer.promise;
+    // resolve if not already rejected
+    defer.resolve();
+    return defer.promise;
 };
 
 var LOC_FRIENDLYNAME = 'loc.friendlyName';
@@ -53,139 +53,144 @@ var LOC_INPUTLABEL = 'loc.input.label.';
 var LOC_INPUTHELP = 'loc.input.help.';
 
 var createStrings = function(task, pkgPath, srcPath) {
-	var defer = Q.defer();
+    var defer = Q.defer();
 
-	var strPath = path.join(pkgPath, _strRelPath);
-	shell.mkdir('-p', strPath);
-	var srcStrPath = path.join(srcPath, _strRelPath);
-	shell.mkdir('-p', srcStrPath);
+    var strPath = path.join(pkgPath, _strRelPath);
+    shell.mkdir('-p', strPath);
+    var srcStrPath = path.join(srcPath, _strRelPath);
+    shell.mkdir('-p', srcStrPath);
 
-	//
-	// Loc tasks.json and product strings content
-	//
-	var strings = {};
-	strings[LOC_FRIENDLYNAME] = task.friendlyName;
-	task['friendlyName'] = 'ms-resource:' + LOC_FRIENDLYNAME;
-	
-	strings[LOC_HELPMARKDOWN] = task.helpMarkDown;
-	task['helpMarkDown'] = 'ms-resource:' + LOC_HELPMARKDOWN;
+    //
+    // Loc tasks.json and product strings content
+    //
+    var strings = {};
+    strings[LOC_FRIENDLYNAME] = task.friendlyName;
+    task['friendlyName'] = 'ms-resource:' + LOC_FRIENDLYNAME;
 
-	strings[LOC_DESCRIPTION] = task.description;
-	task['description'] = 'ms-resource:' + LOC_DESCRIPTION;
+    strings[LOC_HELPMARKDOWN] = task.helpMarkDown;
+    task['helpMarkDown'] = 'ms-resource:' + LOC_HELPMARKDOWN;
 
-	strings[LOC_INSTFORMAT] = task.instanceNameFormat;
-	task['instanceNameFormat'] = 'ms-resource:' + LOC_INSTFORMAT;
+    strings[LOC_DESCRIPTION] = task.description;
+    task['description'] = 'ms-resource:' + LOC_DESCRIPTION;
 
-	if (task.groups) {
-		task.groups.forEach(function(group) {
-			if (group.name) {
-				var key = LOC_GROUPDISPLAYNAME + group.name;
-				strings[key] = group.displayName;
-				group.displayName = 'ms-resource:' + key;
-			}
-		});
-	}
+    strings[LOC_INSTFORMAT] = task.instanceNameFormat;
+    task['instanceNameFormat'] = 'ms-resource:' + LOC_INSTFORMAT;
 
-	if (task.inputs) {
-		task.inputs.forEach(function(input) {
-			if (input.name) {
-				var labelKey = LOC_INPUTLABEL + input.name;
-				strings[labelKey] = input.label;
-				input.label = 'ms-resource:' + labelKey; 
+    if (task.groups) {
+        task.groups.forEach(function(group) {
+            if (group.name) {
+                var key = LOC_GROUPDISPLAYNAME + group.name;
+                strings[key] = group.displayName;
+                group.displayName = 'ms-resource:' + key;
+            }
+        });
+    }
 
-				if (input.helpMarkDown) {
-					var helpKey = LOC_INPUTHELP + input.name;
-					strings[helpKey] = input.helpMarkDown;
-					input.helpMarkDown = 'ms-resource:' + helpKey;				
-				}				
-			}
-		});
-	}	
+    if (task.inputs) {
+        task.inputs.forEach(function(input) {
+            if (input.name) {
+                var labelKey = LOC_INPUTLABEL + input.name;
+                strings[labelKey] = input.label;
+                input.label = 'ms-resource:' + labelKey; 
 
-	//
-	// Write the tasks.json and strings file in package and back to source
-	//
-	var enPath = path.join(strPath, 'resources.resjson');
-	var enSrcPath = path.join(srcStrPath, 'resources.resjson');
+                if (input.helpMarkDown) {
+                    var helpKey = LOC_INPUTHELP + input.name;
+                    strings[helpKey] = input.helpMarkDown;
+                    input.helpMarkDown = 'ms-resource:' + helpKey;
+                }
+            }
+        });
+    }
 
-	var enContents = '' + _banner;
-	enContents += JSON.stringify(strings, null, 2);
-	fs.writeFile(enPath, enContents, function(err) {
-		if (err) {
-			defer.reject(createError('could not create: ' + enPath + ' - ' + err.message));
-			return;
-		}
+    //
+    // Write the tasks.json and strings file in package and back to source
+    //
+    var enPath = path.join(strPath, 'resources.resjson');
+    var enSrcPath = path.join(srcStrPath, 'resources.resjson');
 
-		var taskPath = path.join(pkgPath, 'task.loc.json');
+    var enContents = '' + _banner;
+    enContents += JSON.stringify(strings, null, 2);
+    fs.writeFile(enPath, enContents, function(err) {
+        if (err) {
+            defer.reject(createError('could not create: ' + enPath + ' - ' + err.message));
+            return;
+        }
 
-		var contents = '' + _banner;
-		contents += JSON.stringify(task, null, 2);
+        var taskPath = path.join(pkgPath, 'task.loc.json');
 
-		fs.writeFile(taskPath, contents, function(err) {
-			if (err) {
-				defer.reject(createError('could not create: ' + taskPath + ' - ' + err.message));
-				return;
-			}
+        var contents = '' + _banner;
+        contents += JSON.stringify(task, null, 2);
 
-			// copy the loc assets back to the src so they can be checked in
-			shell.cp('-f', enPath, enSrcPath);
-			shell.cp('-f', taskPath, path.join(srcPath, 'task.loc.json'));
+        fs.writeFile(taskPath, contents, function(err) {
+            if (err) {
+                defer.reject(createError('could not create: ' + taskPath + ' - ' + err.message));
+                return;
+            }
 
-			defer.resolve();			
-		});
+            // copy the loc assets back to the src so they can be checked in
+            shell.cp('-f', enPath, enSrcPath);
+            shell.cp('-f', taskPath, path.join(srcPath, 'task.loc.json'));
 
-	})
+            defer.resolve();			
+        });
 
-	return defer.promise;
+    })
+
+    return defer.promise;
 };
 
 function packageTask(pkgPath){
     return through.obj(
-		function(taskJson, encoding, done) {
-		    if (!fs.existsSync(taskJson)) {
-		        new gutil.PluginError('PackageTask', 'Task json cannot be found: ' + taskJson.path);
-		    }
+            function(taskJson, encoding, done) {
+                if (!fs.existsSync(taskJson)) {
+                    new gutil.PluginError('PackageTask', 'Task json cannot be found: ' + taskJson.path);
+                }
 
-	        if (taskJson.isNull() || taskJson.isDirectory()) {
-	            this.push(taskJson);
-	            return callback();
-	        }
+                if (taskJson.isNull() || taskJson.isDirectory()) {
+                    this.push(taskJson);
+                    return callback();
+                }
 
-	        var dirName = path.dirname(taskJson.path);
-	        var folderName = path.basename(dirName);
-	        var jsonContents = taskJson.contents.toString();
-	        var task = {};
+                var dirName = path.dirname(taskJson.path);
+                var folderName = path.basename(dirName);
+                var jsonContents = taskJson.contents.toString();
+                var task = {};
 
-	        try {
-	        	task = JSON.parse(jsonContents);
-	        }
-	        catch (err) {
-	        	done(createError(folderName + ' parse error: ' + err.message));
-	        	return;
-	        }
+                try {
+                    task = JSON.parse(jsonContents);
+                }
+                catch (err) {
+                    done(createError(folderName + ' parse error: ' + err.message));
+                    return;
+                }
 
-	        var tgtPath;
+                var tgtPath;
 
-	        validate(folderName, task)
-	        .then(function() {
-				gutil.log('Packaging: ' + task.name);
-	        	
-	        	tgtPath = path.join(pkgPath, task.name);
-	        	shell.mkdir('-p', tgtPath);
-	        	shell.cp('-R', path.join(dirName, '*'), tgtPath);
-	        	shell.rm(path.join(tgtPath, '*.csproj'));
-	        	shell.rm(path.join(tgtPath, '*.md'));
-	        	return;        	
-	        })
-	        .then(function() {
-	        	return createStrings(task, tgtPath, dirName);
-	        })
-	        .then(function() {
-	        	done();
-	        })
-	        .fail(function(err) {
-	        	done(err);
-	        })
-		});    
+                validate(folderName, task)
+                    .then(function() {
+                        gutil.log('Packaging: ' + task.name);
+
+                        tgtPath = path.join(pkgPath, task.name);
+                        shell.mkdir('-p', tgtPath);
+                        shell.cp('-R', path.join(dirName, '*'), tgtPath);
+
+                        // Delete Tests directory
+                        shell.rm('-rf', path.join(tgtPath, 'Tests'));
+
+                        // Delete known unnecessary files
+                        shell.rm(path.join(tgtPath, '*.csproj'));
+                        shell.rm(path.join(tgtPath, '*.md'));
+                        return;        	
+                    })
+                .then(function() {
+                    return createStrings(task, tgtPath, dirName);
+                })
+                .then(function() {
+                    done();
+                })
+                .fail(function(err) {
+                    done(err);
+                })
+            });    
 }
 exports.PackageTask = packageTask;


### PR DESCRIPTION
It runs pester tests for the tasks and results are available in the node.exe standard output/error.

Ensure Tests directory in a task is not packaged.

Minor fixes to indentation. Converted tabs to spaces for consistency in both gulpfile.js and package.js.