### PR TITLE
Enabling Cobertura CC tool for Ant and Maven

### DIFF
--- a/Tasks/ANT/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ANT/Strings/resources.resjson/en-US/resources.resjson
@@ -20,7 +20,7 @@
   "loc.input.label.testRunTitle": "Test Run Title",
   "loc.input.help.testRunTitle": "Provide a name for the Test Run.",
   "loc.input.label.codeCoverageTool": "Code Coverage Tool",
-  "loc.input.help.codeCoverageTool": "Select the code coverage tool. Please make sure jacocoant.jar is available in lib folder of Ant installation.",
+  "loc.input.help.codeCoverageTool": "Select the code coverage tool. For JaCoCo, please make sure jacocoant.jar is available in lib folder of Ant installation. For cobertura, set up an environment variable COBERTURA_HOME pointing to the cobertura jars location.",
   "loc.input.label.classFilesDirectories": "Class Files Directories",
   "loc.input.help.classFilesDirectories": "Comma separated list of directories containing class files, archive files(jar, war etc.). Directories and archives are searched recursively for class files. Code coverage is reported for class files present in the directories. For example, classes1/Tests,classes2/Tests2. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html.",
   "loc.input.label.classFilter": "Class Inclusion/Exclusion Filters",

--- a/Tasks/ANT/ant.ps1
+++ b/Tasks/ANT/ant.ps1
@@ -87,15 +87,20 @@ $reportDirectoryName = [guid]::NewGuid()
 $reportDirectory = Join-Path $buildRootPath $reportDirectoryName
 
 $summaryFileName = "summary.xml"
+$summaryFileNameCobertura = "coverage.xml"
 $summaryFile = Join-Path $buildRootPath $reportDirectoryName 
 $summaryFile = Join-Path $summaryFile $summaryFileName
+$summaryFileCobertura = Join-Path $buildRootPath $reportDirectoryName
+$summaryFileCobertura = Join-Path $summaryFileCobertura $summaryFileNameCobertura
 # ensuring unique code coverage report task name by using guid
 $CCReportTask = "CodeCoverage_" +[guid]::NewGuid()
+# ensuring unique instrumentation task name by using guid
+$CCInstrumentTask = "CodeCoverageInstrument_" + [guid]::NewGuid()
 
 if($isCoverageEnabled)
 {
    # Enable code coverage in build file
-   Enable-CodeCoverage -BuildTool 'Ant' -BuildFile $antBuildFile -CodeCoverageTool $codeCoverageTool -ClassFilter $classFilter -ClassFilesDirectories $classFilesDirectories -SourceDirectories $srcDirectories -SummaryFile $summaryFileName -ReportDirectory $reportDirectoryName -CCReportTask $CCReportTask -ErrorAction Stop
+   Enable-CodeCoverage -BuildTool 'Ant' -BuildFile $antBuildFile -CodeCoverageTool $codeCoverageTool -ClassFilter $classFilter -ClassFilesDirectories $classFilesDirectories -SourceDirectories $srcDirectories -SummaryFile $summaryFileName -ReportDirectory $reportDirectoryName -CCReportTask $CCReportTask -CCInstrumentTask $CCInstrumentTask -ErrorAction Stop
    Write-Verbose "Code coverage is successfully enabled." -Verbose
 }
 else
@@ -103,7 +108,7 @@ else
     Write-Verbose "Option to enable code coverage was not selected and is being skipped." -Verbose
 }	
 
-Write-Verbose "Running Ant..."
+Write-Verbose "Running Ant..." -Verbose
 Invoke-Ant -AntBuildFile $antBuildFile -Options $options -Targets $targets
 
 # Publish test results files
@@ -131,29 +136,64 @@ else
 # check if code coverage has been enabled
 if($isCoverageEnabled)
 {
-   # run report code coverage task which generates code coverage reports.
-   $reportsGenerationFailed = $false
-   Write-Verbose "Collecting code coverage reports" -Verbose
-   try
-   {
-		Invoke-Ant -AntBuildFile $antBuildFile -Targets $CCReportTask 
-   }
-   catch
-   {
-		$reportsGenerationFailed = $true
-   }
+	   # run instrumentation task required for cobertura code coverage tool
+	   if ($codeCoverageTool.equals("Cobertura"))
+	   {
+		   # run instrument task which instruments the classes to be covered for report generation
+		   $instrumentationFailed = $false
+		   Write-Verbose "Instrumenting classes for Code Coverage Report generation" -Verbose
+		   try
+		   {
+			   Invoke-Ant -AntBuildFile $antBuildFile -Targets $CCInstrumentTask      
+		   }
+		   catch
+		   {
+			   $instrumentationFailed = $true
+		   }   
+	   }
    
-   if(-not $reportsGenerationFailed -and (Test-Path $summaryFile))
-   {
-		Write-Verbose "Summary file = $summaryFile" -Verbose
-		Write-Verbose "Report directory = $reportDirectory" -Verbose
-		Write-Verbose "Calling Publish-CodeCoverage" -Verbose
-		Publish-CodeCoverage -CodeCoverageTool $codeCoverageTool -SummaryFileLocation $summaryFile -ReportDirectory $reportDirectory -Context $distributedTaskContext    
-   }
-   else
-   {
-        Write-Host "##vso[task.logissue type=warning;code=006003;]"
-		Write-Warning "No code coverage results found to be published. This could occur if there were no tests executed or there was a build failure. Check the ant output for details." -Verbose
+       # run report code coverage task which generates code coverage reports.
+	   $reportsGenerationFailed = $false
+	   Write-Verbose "Collecting code coverage reports" -Verbose
+	   try
+	   {
+			Invoke-Ant -AntBuildFile $antBuildFile -Targets $CCReportTask 
+	   }
+	   catch
+	   {
+			$reportsGenerationFailed = $true
+	   }
+	   
+	if ($codeCoverageTool.equals("Cobertura"))
+	{
+	   if(-not $reportsGenerationFailed -and (Test-Path $summaryFileCobertura) -and -not $instrumentationFailed)
+	   {
+			Write-Verbose "Summary file = $summaryFile" -Verbose
+			Write-Verbose "Report directory = $reportDirectory" -Verbose
+			Write-Verbose "Calling Publish-CodeCoverage" -Verbose
+			Publish-CodeCoverage -CodeCoverageTool $codeCoverageTool -SummaryFileLocation $summaryFileCobertura -ReportDirectory $reportDirectory -Context $distributedTaskContext    
+	   }
+	   else
+	   {
+			Write-Host "##vso[task.logissue type=warning;code=006003;]"
+			Write-Warning "No code coverage results found to be published. This could occur if there were no tests executed or there was a build failure. Check the ant output for details." -Verbose
+	   }
+	}
+	
+    ElseIf ($codeCoverageTool.equals("JaCoCo"))
+	{  
+	   if(-not $reportsGenerationFailed -and (Test-Path $summaryFile))
+	   {
+			Write-Verbose "Summary file = $summaryFile" -Verbose
+			Write-Verbose "Report directory = $reportDirectory" -Verbose
+			Write-Verbose "Calling Publish-CodeCoverage" -Verbose
+			Publish-CodeCoverage -CodeCoverageTool $codeCoverageTool -SummaryFileLocation $summaryFile -ReportDirectory $reportDirectory -Context $distributedTaskContext    
+	   }
+	   else
+	   {
+			Write-Host "##vso[task.logissue type=warning;code=006003;]"
+			Write-Warning "No code coverage results found to be published. This could occur if there were no tests executed or there was a build failure. Check the ant output for details." -Verbose
+	   }
    }
 }
 

--- a/Tasks/ANT/ant.ps1
+++ b/Tasks/ANT/ant.ps1
@@ -86,12 +86,22 @@ $buildRootPath = Split-Path $antBuildFile -Parent
 $reportDirectoryName = [guid]::NewGuid()
 $reportDirectory = Join-Path $buildRootPath $reportDirectoryName
 
-$summaryFileName = "summary.xml"
-$summaryFileNameCobertura = "coverage.xml"
+if($isCoverageEnabled)
+{
+	if ($codeCoverageTool.equals("Cobertura"))
+	{
+		$summaryFileName = "coverage.xml"
+	}
+	ElseIf ($codeCoverageTool.equals("JaCoCo"))
+	{
+		$summaryFileName = "summary.xml"
+	}
+}
+
+
+
 $summaryFile = Join-Path $buildRootPath $reportDirectoryName 
 $summaryFile = Join-Path $summaryFile $summaryFileName
-$summaryFileCobertura = Join-Path $buildRootPath $reportDirectoryName
-$summaryFileCobertura = Join-Path $summaryFileCobertura $summaryFileNameCobertura
 # ensuring unique code coverage report task name by using guid
 $CCReportTask = "CodeCoverage_" +[guid]::NewGuid()
 # ensuring unique instrumentation task name by using guid
@@ -164,37 +174,19 @@ if($isCoverageEnabled)
 			$reportsGenerationFailed = $true
 	   }
 	   
-	if ($codeCoverageTool.equals("Cobertura"))
-	{
-	   if(-not $reportsGenerationFailed -and (Test-Path $summaryFileCobertura) -and -not $instrumentationFailed)
-	   {
-			Write-Verbose "Summary file = $summaryFile" -Verbose
-			Write-Verbose "Report directory = $reportDirectory" -Verbose
-			Write-Verbose "Calling Publish-CodeCoverage" -Verbose
-			Publish-CodeCoverage -CodeCoverageTool $codeCoverageTool -SummaryFileLocation $summaryFileCobertura -ReportDirectory $reportDirectory -Context $distributedTaskContext    
-	   }
-	   else
-	   {
-			Write-Host "##vso[task.logissue type=warning;code=006003;]"
-			Write-Warning "No code coverage results found to be published. This could occur if there were no tests executed or there was a build failure. Check the ant output for details." -Verbose
-	   }
-	}
 	
-    ElseIf ($codeCoverageTool.equals("JaCoCo"))
-	{  
-	   if(-not $reportsGenerationFailed -and (Test-Path $summaryFile))
-	   {
-			Write-Verbose "Summary file = $summaryFile" -Verbose
-			Write-Verbose "Report directory = $reportDirectory" -Verbose
-			Write-Verbose "Calling Publish-CodeCoverage" -Verbose
-			Publish-CodeCoverage -CodeCoverageTool $codeCoverageTool -SummaryFileLocation $summaryFile -ReportDirectory $reportDirectory -Context $distributedTaskContext    
-	   }
-	   else
-	   {
-			Write-Host "##vso[task.logissue type=warning;code=006003;]"
-			Write-Warning "No code coverage results found to be published. This could occur if there were no tests executed or there was a build failure. Check the ant output for details." -Verbose
-	   }
-   }
+	if(-not $reportsGenerationFailed -and (Test-Path $summaryFile) -and -not $instrumentationFailed)
+	{
+		Write-Verbose "Summary file = $summaryFile" -Verbose
+		Write-Verbose "Report directory = $reportDirectory" -Verbose
+		Write-Verbose "Calling Publish-CodeCoverage" -Verbose
+		Publish-CodeCoverage -CodeCoverageTool $codeCoverageTool -SummaryFileLocation $summaryFile -ReportDirectory $reportDirectory -Context $distributedTaskContext    
+	}
+	else
+	{
+		Write-Host "##vso[task.logissue type=warning;code=006003;]"
+		Write-Warning "No code coverage results found to be published. This could occur if there were no tests executed or there was a build failure. Check the ant output for details." -Verbose
+	}
 }
 
 if(Test-Path $reportDirectory)

--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 16
+        "Patch": 17
     },
     "demands" : [
         "ant"
@@ -95,11 +95,11 @@
             "required": false,
             "groupName": "codeCoverage",
             "defaultValue": "None",
-            "helpMarkDown": "Select the code coverage tool. Please make sure jacocoant.jar is available in lib folder of Ant installation.",
+            "helpMarkDown": "Select the code coverage tool. For JaCoCo, please make sure jacocoant.jar is available in lib folder of Ant installation. For cobertura, set up an environment variable COBERTURA_HOME pointing to the cobertura jars location.",
             "options": {
                 "None": "None",
                 "JaCoCo": "JaCoCo",
-				"Cobertura": "Cobertura"
+				        "Cobertura": "Cobertura"
             }
         },        
         {

--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -98,7 +98,8 @@
             "helpMarkDown": "Select the code coverage tool. Please make sure jacocoant.jar is available in lib folder of Ant installation.",
             "options": {
                 "None": "None",
-                "JaCoCo": "JaCoCo"
+                "JaCoCo": "JaCoCo",
+				"Cobertura": "Cobertura"
             }
         },        
         {
@@ -109,7 +110,7 @@
             "required": true,
             "groupName": "codeCoverage",
             "helpMarkDown": "Comma separated list of directories containing class files, archive files(jar, war etc.). Directories and archives are searched recursively for class files. Code coverage is reported for class files present in the directories. For example, classes1/Tests,classes2/Tests2. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html.",
-            "visibleRule": "codeCoverageTool = JaCoCo"
+            "visibleRule": "codeCoverageTool != None"
         },
         {
             "name": "classFilter",
@@ -119,7 +120,7 @@
             "required": false,
             "groupName": "codeCoverage",
             "helpMarkDown": "Comma separated list of filters to include or exclude classes from collecting code coverage. For example, +:com.*,+:org.*,-:my.app*.*. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html.",
-            "visibleRule": "codeCoverageTool = JaCoCo"
+            "visibleRule": "codeCoverageTool != None"
         },
         {
             "name": "srcDirectories",
@@ -129,7 +130,7 @@
             "required": false,
             "groupName": "codeCoverage",
             "helpMarkDown": "Specify source directories for code coverage reports to include highlighted source code. For example, src/java,src/Test. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html.",
-            "visibleRule": "codeCoverageTool = JaCoCo"
+            "visibleRule": "codeCoverageTool != None"
         },
         {
              "name":"javaHomeSelection",

--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -99,7 +99,7 @@
             "options": {
                 "None": "None",
                 "JaCoCo": "JaCoCo",
-				        "Cobertura": "Cobertura"
+		"Cobertura": "Cobertura"
             }
         },        
         {

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -102,7 +102,8 @@
       "helpMarkDown": "ms-resource:loc.input.help.codeCoverageTool",
       "options": {
         "None": "None",
-        "JaCoCo": "JaCoCo"
+        "JaCoCo": "JaCoCo",
+        "Cobertura": "Cobertura"
       }
     },
     {
@@ -113,7 +114,7 @@
       "required": true,
       "groupName": "codeCoverage",
       "helpMarkDown": "ms-resource:loc.input.help.classFilesDirectories",
-      "visibleRule": "codeCoverageTool = JaCoCo"
+      "visibleRule": "codeCoverageTool != None"
     },
     {
       "name": "classFilter",
@@ -123,7 +124,7 @@
       "required": false,
       "groupName": "codeCoverage",
       "helpMarkDown": "ms-resource:loc.input.help.classFilter",
-      "visibleRule": "codeCoverageTool = JaCoCo"
+      "visibleRule": "codeCoverageTool != None"
     },
     {
       "name": "srcDirectories",
@@ -133,7 +134,7 @@
       "required": false,
       "groupName": "codeCoverage",
       "helpMarkDown": "ms-resource:loc.input.help.srcDirectories",
-      "visibleRule": "codeCoverageTool = JaCoCo"
+      "visibleRule": "codeCoverageTool != None"
     },
     {
       "name": "javaHomeSelection",

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 16
+    "Patch": 17
   },
   "demands": [
     "ant"

--- a/Tasks/Maven/maven.ps1
+++ b/Tasks/Maven/maven.ps1
@@ -64,15 +64,15 @@ import-module "Microsoft.TeamFoundation.DistributedTask.Task.TestResults"
 
 
 $buildRootPath = Split-Path $mavenPOMFile -Parent
-$reportDirectoryNameJacoco = [guid]::NewGuid()
+$reportDirectoryName = [guid]::NewGuid()
 $reportDirectoryNameCobertura = "target\site\cobertura"
 $reportPOMFileName = [guid]::NewGuid().tostring() + ".xml"
 $reportPOMFile = Join-Path $buildRootPath $reportPOMFileName
-$reportDirectoryJacoco = Join-Path $buildRootPath $reportDirectoryNameJacoco
+$reportDirectory = Join-Path $buildRootPath $reportDirectoryName
 $reportDirectoryCobertura = Join-Path $buildRootPath $reportDirectoryNameCobertura
 $summaryFileNameJacoco = "jacoco.xml"
 $summaryFileNameCobertura = "coverage.xml"
-$summaryFileJacoco = Join-Path $buildRootPath $reportDirectoryNameJacoco
+$summaryFileJacoco = Join-Path $buildRootPath $reportDirectoryName
 $summaryFileJacoco = Join-Path $summaryFileJacoco $summaryFileNameJacoco
 $summaryFileCobertura = Join-Path $buildRootPath $reportDirectoryNameCobertura
 $summaryFileCobertura = Join-Path $summaryFileCobertura $summaryFileNameCobertura
@@ -81,7 +81,7 @@ $CCReportTask = "jacoco:report"
 Write-Verbose "SummaryFileCobertura = $summaryFileCobertura"
 
 # Enable Code Coverage
-EnableCodeCoverage $isCoverageEnabled $mavenPOMFile $codeCoverageTool $classFilter $classFilesDirectories $srcDirectories $summaryFileNameJacoco $reportDirectoryJacoco $reportPOMFile
+EnableCodeCoverage $isCoverageEnabled $mavenPOMFile $codeCoverageTool $classFilter $classFilesDirectories $srcDirectories $summaryFileNameJacoco $reportDirectory $reportPOMFile
 
 # Use a specific JDK
 ConfigureJDK $javaHomeSelection $jdkVersion $jdkArchitecture $jdkUserInputPath
@@ -96,7 +96,7 @@ PublishTestResults $publishJUnitResults $testResultsFiles $testRunTitle
 if ($codeCoverageTool.equals("JaCoCo"))
 {
 	# Publish code coverage for Jacoco
-	PublishCodeCoverageJacoco  $isCoverageEnabled $mavenPOMFile $CCReportTask $summaryFileJacoco $reportDirectoryJacoco $codeCoverageTool $reportPOMFile
+	PublishCodeCoverageJacoco  $isCoverageEnabled $mavenPOMFile $CCReportTask $summaryFileJacoco $reportDirectory $codeCoverageTool $reportPOMFile
 }
 ElseIf ($codeCoverageTool.equals("Cobertura"))
 {
@@ -104,15 +104,15 @@ ElseIf ($codeCoverageTool.equals("Cobertura"))
 	PublishCodeCoverageCobertura  $isCoverageEnabled $mavenPOMFile $summaryFileCobertura $reportDirectoryCobertura $codeCoverageTool
 }
 
-if(Test-Path $reportDirectoryJacoco)
+if(Test-Path $reportDirectory)
 {
     # delete any previous code coverage data 
-    rm -r $reportDirectoryJacoco -force | Out-Null
+    rm -r $reportDirectory -force | Out-Null
 }
 
 if(Test-Path $reportDirectoryCobertura)
 {
-    # delete any previous code coverage data 
+    # delete any previous code coverage data from Cobertura
     rm -r $reportDirectoryCobertura -force | Out-Null
 }
 

--- a/Tasks/Maven/mavenHelper.ps1
+++ b/Tasks/Maven/mavenHelper.ps1
@@ -177,7 +177,7 @@ function CreateSonarQubeArgs
 }
 
 
-function PublishCodeCoverage
+function PublishCodeCoverageJacoco
 {
     param(
           [Boolean]$isCoverageEnabled,
@@ -212,6 +212,33 @@ function PublishCodeCoverage
 		}
        
        if(-not $reportsGenerationFailed -and (Test-Path $summaryFile))
+       {
+    		Write-Verbose "Summary file = $summaryFile" -Verbose
+    		Write-Verbose "Report directory = $reportDirectory" -Verbose
+    		Write-Verbose "Calling Publish-CodeCoverage" -Verbose
+    		Publish-CodeCoverage -CodeCoverageTool $codeCoverageTool -SummaryFileLocation $summaryFile -ReportDirectory $reportDirectory -Context $distributedTaskContext    
+       }
+       else
+       {
+    		Write-Warning "No code coverage found to publish. There might be a build failure resulting in no code coverage or there might be no tests." -Verbose
+       }
+    }
+
+}
+
+function PublishCodeCoverageCobertura
+{
+    param(
+          [Boolean]$isCoverageEnabled,
+	      [string]$mavenPOMFile,
+		  [string]$summaryFile,
+		  [string]$reportDirectory,
+		  [string]$codeCoverageTool)
+	
+     # check if code coverage has been enabled
+    if($isCoverageEnabled)
+    {       
+       if(Test-Path $summaryFile)
        {
     		Write-Verbose "Summary file = $summaryFile" -Verbose
     		Write-Verbose "Report directory = $reportDirectory" -Verbose

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 19
+        "Patch": 20
     },
    "minimumAgentVersion": "1.91.0",
     "instanceNameFormat": "Maven $(mavenPOMFile)",
@@ -104,8 +104,8 @@
             "helpMarkDown": "Select the code coverage tool.",
             "options": {
                 "None": "None",
-              "JaCoCo": "JaCoCo",
-              "Cobertura": "Cobertura"
+                "JaCoCo": "JaCoCo",
+                "Cobertura": "Cobertura"
             }
         },
         {
@@ -116,7 +116,7 @@
             "required": false,
             "groupName": "codeCoverage",
             "helpMarkDown": "Comma separated list of filters to include or exclude classes from collecting code coverage. For example, +:com.*,+:org.*,-:my.app*.*. Refer http://www.eclemma.org/jacoco/trunk/doc/maven.html.",
-			"visibleRule": "codeCoverageTool != None"
+			      "visibleRule": "codeCoverageTool != None"
         }, 
         {
             "name": "classFilesDirectories",
@@ -125,7 +125,7 @@
             "required": false,
             "groupName": "codeCoverage",
             "helpMarkDown": "This field is required for a multi module project. Code coverage reports are created using ANT task. Comma separated list of directories containing class files, archive files(jar, war etc.). Directories and archives are searched recursively for class files. Code coverage is reported for class files present in the directories. For example, classes1/Tests,classes2/Tests2. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html",
-			"visibleRule": "codeCoverageTool != None"
+			      "visibleRule": "codeCoverageTool = JaCoCo"
         },	
         {
             "name": "srcDirectories",
@@ -135,8 +135,8 @@
             "required": false,
             "groupName": "codeCoverage",
             "helpMarkDown": "This field is required for a multi module project. Code coverage reports are created using ANT task. Specify source directories for code coverage reports to include highlighted source code. For example, src/java,src/Test. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html",
-			"visibleRule": "codeCoverageTool != None"
-        },		
+			      "visibleRule": "codeCoverageTool != None"
+        },	
         {
             "name":"javaHomeSelection",
             "type":"radio",

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -104,7 +104,8 @@
             "helpMarkDown": "Select the code coverage tool.",
             "options": {
                 "None": "None",
-                "JaCoCo": "JaCoCo"
+              "JaCoCo": "JaCoCo",
+              "Cobertura": "Cobertura"
             }
         },
         {
@@ -114,8 +115,7 @@
             "defaultValue": "",
             "required": false,
             "groupName": "codeCoverage",
-            "helpMarkDown": "Comma separated list of filters to include or exclude classes from collecting code coverage. For example, +:com.*,+:org.*,-:my.app*.*. Refer http://www.eclemma.org/jacoco/trunk/doc/maven.html.",
-            "visibleRule": "codeCoverageTool = JaCoCo"
+            "helpMarkDown": "Comma separated list of filters to include or exclude classes from collecting code coverage. For example, +:com.*,+:org.*,-:my.app*.*. Refer http://www.eclemma.org/jacoco/trunk/doc/maven.html."
         }, 
         {
             "name": "classFilesDirectories",
@@ -123,8 +123,7 @@
             "label": "Class Files Directories",
             "required": false,
             "groupName": "codeCoverage",
-            "helpMarkDown": "This field is required for a multi module project. Code coverage reports are created using ANT task. Comma separated list of directories containing class files, archive files(jar, war etc.). Directories and archives are searched recursively for class files. Code coverage is reported for class files present in the directories. For example, classes1/Tests,classes2/Tests2. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html",
-            "visibleRule": "codeCoverageTool = JaCoCo"
+            "helpMarkDown": "This field is required for a multi module project. Code coverage reports are created using ANT task. Comma separated list of directories containing class files, archive files(jar, war etc.). Directories and archives are searched recursively for class files. Code coverage is reported for class files present in the directories. For example, classes1/Tests,classes2/Tests2. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html"
         },	
         {
             "name": "srcDirectories",
@@ -133,8 +132,7 @@
             "defaultValue": "",
             "required": false,
             "groupName": "codeCoverage",
-            "helpMarkDown": "This field is required for a multi module project. Code coverage reports are created using ANT task. Specify source directories for code coverage reports to include highlighted source code. For example, src/java,src/Test. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html",
-            "visibleRule": "codeCoverageTool = JaCoCo"
+            "helpMarkDown": "This field is required for a multi module project. Code coverage reports are created using ANT task. Specify source directories for code coverage reports to include highlighted source code. For example, src/java,src/Test. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html"
         },		
         {
             "name":"javaHomeSelection",
@@ -192,7 +190,7 @@
             "name": "sqAnalysisEnabled",
             "type": "boolean",
             "label": "Run SonarQube Analysis",
-            "required": true,
+            "required": false,
             "defaultValue": "false",
             "groupName": "SQAnalysis",
             "helpMarkDown": "Run a [SonarQube](http://www.sonarqube.org/) analysis after executing the current goals. 'install' or 'package' goals should be executed first."
@@ -201,7 +199,7 @@
             "name": "sqConnectedServiceName",
             "type": "connectedService:Generic",
             "label": "SonarQube Endpoint",
-            "required": true,
+            "required": false,
             "helpMarkDown": "The endpoint that specifies the SonarQube server to use",
             "groupName": "SQAnalysis",
             "visibleRule": "sqAnalysisEnabled = true"
@@ -210,7 +208,7 @@
             "name": "sqDbDetailsRequired",
             "type": "boolean",
             "label": "The SonarQube server version is lower than 5.2",
-            "required": true,
+            "required": false,
             "defaultValue": "false",
             "groupName": "SQAnalysis",
             "helpMarkDown": "If using a SonarQube server 5.1 or lower you need to specify the database connection details.",

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -115,7 +115,8 @@
             "defaultValue": "",
             "required": false,
             "groupName": "codeCoverage",
-            "helpMarkDown": "Comma separated list of filters to include or exclude classes from collecting code coverage. For example, +:com.*,+:org.*,-:my.app*.*. Refer http://www.eclemma.org/jacoco/trunk/doc/maven.html."
+            "helpMarkDown": "Comma separated list of filters to include or exclude classes from collecting code coverage. For example, +:com.*,+:org.*,-:my.app*.*. Refer http://www.eclemma.org/jacoco/trunk/doc/maven.html.",
+			"visibleRule": "codeCoverageTool != None"
         }, 
         {
             "name": "classFilesDirectories",
@@ -123,7 +124,8 @@
             "label": "Class Files Directories",
             "required": false,
             "groupName": "codeCoverage",
-            "helpMarkDown": "This field is required for a multi module project. Code coverage reports are created using ANT task. Comma separated list of directories containing class files, archive files(jar, war etc.). Directories and archives are searched recursively for class files. Code coverage is reported for class files present in the directories. For example, classes1/Tests,classes2/Tests2. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html"
+            "helpMarkDown": "This field is required for a multi module project. Code coverage reports are created using ANT task. Comma separated list of directories containing class files, archive files(jar, war etc.). Directories and archives are searched recursively for class files. Code coverage is reported for class files present in the directories. For example, classes1/Tests,classes2/Tests2. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html",
+			"visibleRule": "codeCoverageTool != None"
         },	
         {
             "name": "srcDirectories",
@@ -132,7 +134,8 @@
             "defaultValue": "",
             "required": false,
             "groupName": "codeCoverage",
-            "helpMarkDown": "This field is required for a multi module project. Code coverage reports are created using ANT task. Specify source directories for code coverage reports to include highlighted source code. For example, src/java,src/Test. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html"
+            "helpMarkDown": "This field is required for a multi module project. Code coverage reports are created using ANT task. Specify source directories for code coverage reports to include highlighted source code. For example, src/java,src/Test. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html",
+			"visibleRule": "codeCoverageTool != None"
         },		
         {
             "name":"javaHomeSelection",
@@ -190,7 +193,7 @@
             "name": "sqAnalysisEnabled",
             "type": "boolean",
             "label": "Run SonarQube Analysis",
-            "required": false,
+            "required": true,
             "defaultValue": "false",
             "groupName": "SQAnalysis",
             "helpMarkDown": "Run a [SonarQube](http://www.sonarqube.org/) analysis after executing the current goals. 'install' or 'package' goals should be executed first."
@@ -199,7 +202,7 @@
             "name": "sqConnectedServiceName",
             "type": "connectedService:Generic",
             "label": "SonarQube Endpoint",
-            "required": false,
+            "required": true,
             "helpMarkDown": "The endpoint that specifies the SonarQube server to use",
             "groupName": "SQAnalysis",
             "visibleRule": "sqAnalysisEnabled = true"
@@ -208,7 +211,7 @@
             "name": "sqDbDetailsRequired",
             "type": "boolean",
             "label": "The SonarQube server version is lower than 5.2",
-            "required": false,
+            "required": true,
             "defaultValue": "false",
             "groupName": "SQAnalysis",
             "helpMarkDown": "If using a SonarQube server 5.1 or lower you need to specify the database connection details.",

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -116,7 +116,7 @@
             "required": false,
             "groupName": "codeCoverage",
             "helpMarkDown": "Comma separated list of filters to include or exclude classes from collecting code coverage. For example, +:com.*,+:org.*,-:my.app*.*. Refer http://www.eclemma.org/jacoco/trunk/doc/maven.html.",
-			      "visibleRule": "codeCoverageTool != None"
+            "visibleRule": "codeCoverageTool != None"
         }, 
         {
             "name": "classFilesDirectories",
@@ -125,7 +125,7 @@
             "required": false,
             "groupName": "codeCoverage",
             "helpMarkDown": "This field is required for a multi module project. Code coverage reports are created using ANT task. Comma separated list of directories containing class files, archive files(jar, war etc.). Directories and archives are searched recursively for class files. Code coverage is reported for class files present in the directories. For example, classes1/Tests,classes2/Tests2. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html",
-			      "visibleRule": "codeCoverageTool = JaCoCo"
+	    "visibleRule": "codeCoverageTool = JaCoCo"
         },	
         {
             "name": "srcDirectories",
@@ -135,7 +135,7 @@
             "required": false,
             "groupName": "codeCoverage",
             "helpMarkDown": "This field is required for a multi module project. Code coverage reports are created using ANT task. Specify source directories for code coverage reports to include highlighted source code. For example, src/java,src/Test. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html",
-			      "visibleRule": "codeCoverageTool != None"
+	    "visibleRule": "codeCoverageTool != None"
         },	
         {
             "name":"javaHomeSelection",

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 19
+    "Patch": 21
   },
   "minimumAgentVersion": "1.91.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 21
+    "Patch": 19
   },
   "minimumAgentVersion": "1.91.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -118,7 +118,8 @@
       "defaultValue": "",
       "required": false,
       "groupName": "codeCoverage",
-      "helpMarkDown": "ms-resource:loc.input.help.classFilter"
+      "helpMarkDown": "ms-resource:loc.input.help.classFilter",
+      "visibleRule": "codeCoverageTool != None"
     },
     {
       "name": "classFilesDirectories",
@@ -126,7 +127,8 @@
       "label": "ms-resource:loc.input.label.classFilesDirectories",
       "required": false,
       "groupName": "codeCoverage",
-      "helpMarkDown": "ms-resource:loc.input.help.classFilesDirectories"
+      "helpMarkDown": "ms-resource:loc.input.help.classFilesDirectories",
+      "visibleRule": "codeCoverageTool != None"
     },
     {
       "name": "srcDirectories",
@@ -135,7 +137,8 @@
       "defaultValue": "",
       "required": false,
       "groupName": "codeCoverage",
-      "helpMarkDown": "ms-resource:loc.input.help.srcDirectories"
+      "helpMarkDown": "ms-resource:loc.input.help.srcDirectories",
+      "visibleRule": "codeCoverageTool != None"
     },
     {
       "name": "javaHomeSelection",
@@ -193,7 +196,7 @@
       "name": "sqAnalysisEnabled",
       "type": "boolean",
       "label": "ms-resource:loc.input.label.sqAnalysisEnabled",
-      "required": false,
+      "required": true,
       "defaultValue": "false",
       "groupName": "SQAnalysis",
       "helpMarkDown": "ms-resource:loc.input.help.sqAnalysisEnabled"
@@ -202,7 +205,7 @@
       "name": "sqConnectedServiceName",
       "type": "connectedService:Generic",
       "label": "ms-resource:loc.input.label.sqConnectedServiceName",
-      "required": false,
+      "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.sqConnectedServiceName",
       "groupName": "SQAnalysis",
       "visibleRule": "sqAnalysisEnabled = true"
@@ -211,7 +214,7 @@
       "name": "sqDbDetailsRequired",
       "type": "boolean",
       "label": "ms-resource:loc.input.label.sqDbDetailsRequired",
-      "required": false,
+      "required": true,
       "defaultValue": "false",
       "groupName": "SQAnalysis",
       "helpMarkDown": "ms-resource:loc.input.help.sqDbDetailsRequired",

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -107,7 +107,8 @@
       "helpMarkDown": "ms-resource:loc.input.help.codeCoverageTool",
       "options": {
         "None": "None",
-        "JaCoCo": "JaCoCo"
+        "JaCoCo": "JaCoCo",
+        "Cobertura": "Cobertura"
       }
     },
     {
@@ -117,8 +118,7 @@
       "defaultValue": "",
       "required": false,
       "groupName": "codeCoverage",
-      "helpMarkDown": "ms-resource:loc.input.help.classFilter",
-      "visibleRule": "codeCoverageTool = JaCoCo"
+      "helpMarkDown": "ms-resource:loc.input.help.classFilter"
     },
     {
       "name": "classFilesDirectories",
@@ -126,8 +126,7 @@
       "label": "ms-resource:loc.input.label.classFilesDirectories",
       "required": false,
       "groupName": "codeCoverage",
-      "helpMarkDown": "ms-resource:loc.input.help.classFilesDirectories",
-      "visibleRule": "codeCoverageTool = JaCoCo"
+      "helpMarkDown": "ms-resource:loc.input.help.classFilesDirectories"
     },
     {
       "name": "srcDirectories",
@@ -136,8 +135,7 @@
       "defaultValue": "",
       "required": false,
       "groupName": "codeCoverage",
-      "helpMarkDown": "ms-resource:loc.input.help.srcDirectories",
-      "visibleRule": "codeCoverageTool = JaCoCo"
+      "helpMarkDown": "ms-resource:loc.input.help.srcDirectories"
     },
     {
       "name": "javaHomeSelection",
@@ -195,7 +193,7 @@
       "name": "sqAnalysisEnabled",
       "type": "boolean",
       "label": "ms-resource:loc.input.label.sqAnalysisEnabled",
-      "required": true,
+      "required": false,
       "defaultValue": "false",
       "groupName": "SQAnalysis",
       "helpMarkDown": "ms-resource:loc.input.help.sqAnalysisEnabled"
@@ -204,7 +202,7 @@
       "name": "sqConnectedServiceName",
       "type": "connectedService:Generic",
       "label": "ms-resource:loc.input.label.sqConnectedServiceName",
-      "required": true,
+      "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.sqConnectedServiceName",
       "groupName": "SQAnalysis",
       "visibleRule": "sqAnalysisEnabled = true"
@@ -213,7 +211,7 @@
       "name": "sqDbDetailsRequired",
       "type": "boolean",
       "label": "ms-resource:loc.input.label.sqDbDetailsRequired",
-      "required": true,
+      "required": false,
       "defaultValue": "false",
       "groupName": "SQAnalysis",
       "helpMarkDown": "ms-resource:loc.input.help.sqDbDetailsRequired",

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 19
+    "Patch": 20
   },
   "minimumAgentVersion": "1.91.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -128,7 +128,7 @@
       "required": false,
       "groupName": "codeCoverage",
       "helpMarkDown": "ms-resource:loc.input.help.classFilesDirectories",
-      "visibleRule": "codeCoverageTool != None"
+      "visibleRule": "codeCoverageTool = JaCoCo"
     },
     {
       "name": "srcDirectories",


### PR DESCRIPTION
Description: Currently we support only JaCoCo as Code Coverage tools for Ant and Maven tasks. This code change adds the support of using Cobertura for these tasks.

Testing: Unit Testing and Manual Testing. Functional tests pending.