### PR TITLE
Fixing issue that was causing some ps1 files to search for modules

### DIFF
--- a/Tasks/AzureFileCopy/AzureFileCopy.ps1
+++ b/Tasks/AzureFileCopy/AzureFileCopy.ps1
@@ -46,6 +46,7 @@ Import-Module ./Utility.ps1 -Force
 
 # Import all the dlls and modules which have cmdlets we need
 Import-Module "Microsoft.TeamFoundation.DistributedTask.Task.Internal"
+Import-Module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
 Import-Module "Microsoft.TeamFoundation.DistributedTask.Task.Deployment.Internal"
 Import-Module "Microsoft.TeamFoundation.DistributedTask.Task.DevTestLabs"
 

--- a/Tasks/CopyPublishBuildArtifacts/CopyPublishBuildArtifacts.ps1
+++ b/Tasks/CopyPublishBuildArtifacts/CopyPublishBuildArtifacts.ps1
@@ -26,6 +26,7 @@ Write-Verbose "TargetPath = $TargetPath"
 
 # Import the Task.Internal dll that has all the cmdlets we need for Build
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Internal"
+import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
 
 $buildId = Get-TaskVariable $distributedTaskContext "build.buildId"
 $teamProjectId = Get-TaskVariable $distributedTaskContext "system.teamProjectId"


### PR DESCRIPTION
Adding import-module statements to the places that are using Get-LocalizedString that didn't already have them.