### PR TITLE
Enabling Cobertura CC tool for Ant and Maven

### DIFF
--- a/Tasks/ANT/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ANT/Strings/resources.resjson/en-US/resources.resjson
@@ -20,7 +20,7 @@
   "loc.input.label.testRunTitle": "Test Run Title",
   "loc.input.help.testRunTitle": "Provide a name for the Test Run.",
   "loc.input.label.codeCoverageTool": "Code Coverage Tool",
-  "loc.input.help.codeCoverageTool": "Select the code coverage tool. Please make sure jacocoant.jar is available in lib folder of Ant installation.",
+  "loc.input.help.codeCoverageTool": "Select the code coverage tool. For JaCoCo, please make sure jacocoant.jar is available in lib folder of Ant installation. For cobertura, set up an environment variable COBERTURA_HOME pointing to the cobertura jars location.",
   "loc.input.label.classFilesDirectories": "Class Files Directories",
   "loc.input.help.classFilesDirectories": "Comma separated list of directories containing class files, archive files(jar, war etc.). Directories and archives are searched recursively for class files. Code coverage is reported for class files present in the directories. For example, classes1/Tests,classes2/Tests2. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html.",
   "loc.input.label.classFilter": "Class Inclusion/Exclusion Filters",

--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 16
+        "Patch": 17
     },
     "demands" : [
         "ant"
@@ -95,10 +95,11 @@
             "required": false,
             "groupName": "codeCoverage",
             "defaultValue": "None",
-            "helpMarkDown": "Select the code coverage tool. Please make sure jacocoant.jar is available in lib folder of Ant installation.",
+            "helpMarkDown": "Select the code coverage tool. For JaCoCo, please make sure jacocoant.jar is available in lib folder of Ant installation. For cobertura, set up an environment variable COBERTURA_HOME pointing to the cobertura jars location.",
             "options": {
                 "None": "None",
-                "JaCoCo": "JaCoCo"
+                "JaCoCo": "JaCoCo",
+		"Cobertura": "Cobertura"
             }
         },        
         {
@@ -109,7 +110,7 @@
             "required": true,
             "groupName": "codeCoverage",
             "helpMarkDown": "Comma separated list of directories containing class files, archive files(jar, war etc.). Directories and archives are searched recursively for class files. Code coverage is reported for class files present in the directories. For example, classes1/Tests,classes2/Tests2. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html.",
-            "visibleRule": "codeCoverageTool = JaCoCo"
+            "visibleRule": "codeCoverageTool != None"
         },
         {
             "name": "classFilter",
@@ -119,7 +120,7 @@
             "required": false,
             "groupName": "codeCoverage",
             "helpMarkDown": "Comma separated list of filters to include or exclude classes from collecting code coverage. For example, +:com.*,+:org.*,-:my.app*.*. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html.",
-            "visibleRule": "codeCoverageTool = JaCoCo"
+            "visibleRule": "codeCoverageTool != None"
         },
         {
             "name": "srcDirectories",
@@ -129,7 +130,7 @@
             "required": false,
             "groupName": "codeCoverage",
             "helpMarkDown": "Specify source directories for code coverage reports to include highlighted source code. For example, src/java,src/Test. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html.",
-            "visibleRule": "codeCoverageTool = JaCoCo"
+            "visibleRule": "codeCoverageTool != None"
         },
         {
              "name":"javaHomeSelection",

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 16
+    "Patch": 17
   },
   "demands": [
     "ant"
@@ -102,7 +102,8 @@
       "helpMarkDown": "ms-resource:loc.input.help.codeCoverageTool",
       "options": {
         "None": "None",
-        "JaCoCo": "JaCoCo"
+        "JaCoCo": "JaCoCo",
+        "Cobertura": "Cobertura"
       }
     },
     {
@@ -113,7 +114,7 @@
       "required": true,
       "groupName": "codeCoverage",
       "helpMarkDown": "ms-resource:loc.input.help.classFilesDirectories",
-      "visibleRule": "codeCoverageTool = JaCoCo"
+      "visibleRule": "codeCoverageTool != None"
     },
     {
       "name": "classFilter",
@@ -123,7 +124,7 @@
       "required": false,
       "groupName": "codeCoverage",
       "helpMarkDown": "ms-resource:loc.input.help.classFilter",
-      "visibleRule": "codeCoverageTool = JaCoCo"
+      "visibleRule": "codeCoverageTool != None"
     },
     {
       "name": "srcDirectories",
@@ -133,7 +134,7 @@
       "required": false,
       "groupName": "codeCoverage",
       "helpMarkDown": "ms-resource:loc.input.help.srcDirectories",
-      "visibleRule": "codeCoverageTool = JaCoCo"
+      "visibleRule": "codeCoverageTool != None"
     },
     {
       "name": "javaHomeSelection",

--- a/Tasks/Maven/maven.ps1
+++ b/Tasks/Maven/maven.ps1
@@ -65,16 +65,23 @@ import-module "Microsoft.TeamFoundation.DistributedTask.Task.TestResults"
 
 $buildRootPath = Split-Path $mavenPOMFile -Parent
 $reportDirectoryName = [guid]::NewGuid()
+$reportDirectoryNameCobertura = "target\site\cobertura"
 $reportPOMFileName = [guid]::NewGuid().tostring() + ".xml"
 $reportPOMFile = Join-Path $buildRootPath $reportPOMFileName
 $reportDirectory = Join-Path $buildRootPath $reportDirectoryName
-$summaryFileName = "jacoco.xml"
-$summaryFile = Join-Path $buildRootPath $reportDirectoryName 
-$summaryFile = Join-Path $summaryFile $summaryFileName
+$reportDirectoryCobertura = Join-Path $buildRootPath $reportDirectoryNameCobertura
+$summaryFileNameJacoco = "jacoco.xml"
+$summaryFileNameCobertura = "coverage.xml"
+$summaryFileJacoco = Join-Path $buildRootPath $reportDirectoryName
+$summaryFileJacoco = Join-Path $summaryFileJacoco $summaryFileNameJacoco
+$summaryFileCobertura = Join-Path $buildRootPath $reportDirectoryNameCobertura
+$summaryFileCobertura = Join-Path $summaryFileCobertura $summaryFileNameCobertura
 $CCReportTask = "jacoco:report"
 
+Write-Verbose "SummaryFileCobertura = $summaryFileCobertura"
+
 # Enable Code Coverage
-EnableCodeCoverage $isCoverageEnabled $mavenPOMFile $codeCoverageTool $classFilter $classFilesDirectories $srcDirectories $summaryFileName $reportDirectory $reportPOMFile
+EnableCodeCoverage $isCoverageEnabled $mavenPOMFile $codeCoverageTool $classFilter $classFilesDirectories $srcDirectories $summaryFileNameJacoco $reportDirectory $reportPOMFile
 
 # Use a specific JDK
 ConfigureJDK $javaHomeSelection $jdkVersion $jdkArchitecture $jdkUserInputPath
@@ -86,14 +93,29 @@ Invoke-Maven -MavenPomFile $mavenPOMFile -Options $options -Goals $goals
 # Publish test results
 PublishTestResults $publishJUnitResults $testResultsFiles $testRunTitle
 
-# Publish code coverage
-PublishCodeCoverage  $isCoverageEnabled $mavenPOMFile $CCReportTask $summaryFile $reportDirectory $codeCoverageTool $reportPOMFile
+if ($codeCoverageTool.equals("JaCoCo"))
+{
+	# Publish code coverage for Jacoco
+	PublishCodeCoverageJacoco  $isCoverageEnabled $mavenPOMFile $CCReportTask $summaryFileJacoco $reportDirectory $codeCoverageTool $reportPOMFile
+}
+ElseIf ($codeCoverageTool.equals("Cobertura"))
+{
+	# Publish code coverage for Jacoco
+	PublishCodeCoverageCobertura  $isCoverageEnabled $mavenPOMFile $summaryFileCobertura $reportDirectoryCobertura $codeCoverageTool
+}
 
 if(Test-Path $reportDirectory)
 {
     # delete any previous code coverage data 
     rm -r $reportDirectory -force | Out-Null
 }
+
+if(Test-Path $reportDirectoryCobertura)
+{
+    # delete any previous code coverage data from Cobertura
+    rm -r $reportDirectoryCobertura -force | Out-Null
+}
+
 if(Test-Path $reportPOMFile)
 {
     # delete any previous code coverage data 

--- a/Tasks/Maven/mavenHelper.ps1
+++ b/Tasks/Maven/mavenHelper.ps1
@@ -177,7 +177,7 @@ function CreateSonarQubeArgs
 }
 
 
-function PublishCodeCoverage
+function PublishCodeCoverageJacoco
 {
     param(
           [Boolean]$isCoverageEnabled,
@@ -212,6 +212,33 @@ function PublishCodeCoverage
 		}
        
        if(-not $reportsGenerationFailed -and (Test-Path $summaryFile))
+       {
+    		Write-Verbose "Summary file = $summaryFile" -Verbose
+    		Write-Verbose "Report directory = $reportDirectory" -Verbose
+    		Write-Verbose "Calling Publish-CodeCoverage" -Verbose
+    		Publish-CodeCoverage -CodeCoverageTool $codeCoverageTool -SummaryFileLocation $summaryFile -ReportDirectory $reportDirectory -Context $distributedTaskContext    
+       }
+       else
+       {
+    		Write-Warning "No code coverage found to publish. There might be a build failure resulting in no code coverage or there might be no tests." -Verbose
+       }
+    }
+
+}
+
+function PublishCodeCoverageCobertura
+{
+    param(
+          [Boolean]$isCoverageEnabled,
+	      [string]$mavenPOMFile,
+		  [string]$summaryFile,
+		  [string]$reportDirectory,
+		  [string]$codeCoverageTool)
+	
+     # check if code coverage has been enabled
+    if($isCoverageEnabled)
+    {       
+       if(Test-Path $summaryFile)
        {
     		Write-Verbose "Summary file = $summaryFile" -Verbose
     		Write-Verbose "Report directory = $reportDirectory" -Verbose

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 19
+        "Patch": 20
     },
    "minimumAgentVersion": "1.91.0",
     "instanceNameFormat": "Maven $(mavenPOMFile)",
@@ -104,7 +104,8 @@
             "helpMarkDown": "Select the code coverage tool.",
             "options": {
                 "None": "None",
-                "JaCoCo": "JaCoCo"
+                "JaCoCo": "JaCoCo",
+                "Cobertura": "Cobertura"
             }
         },
         {
@@ -115,7 +116,7 @@
             "required": false,
             "groupName": "codeCoverage",
             "helpMarkDown": "Comma separated list of filters to include or exclude classes from collecting code coverage. For example, +:com.*,+:org.*,-:my.app*.*. Refer http://www.eclemma.org/jacoco/trunk/doc/maven.html.",
-            "visibleRule": "codeCoverageTool = JaCoCo"
+            "visibleRule": "codeCoverageTool != None"
         }, 
         {
             "name": "classFilesDirectories",
@@ -124,7 +125,7 @@
             "required": false,
             "groupName": "codeCoverage",
             "helpMarkDown": "This field is required for a multi module project. Code coverage reports are created using ANT task. Comma separated list of directories containing class files, archive files(jar, war etc.). Directories and archives are searched recursively for class files. Code coverage is reported for class files present in the directories. For example, classes1/Tests,classes2/Tests2. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html",
-            "visibleRule": "codeCoverageTool = JaCoCo"
+	    "visibleRule": "codeCoverageTool = JaCoCo"
         },	
         {
             "name": "srcDirectories",
@@ -134,8 +135,8 @@
             "required": false,
             "groupName": "codeCoverage",
             "helpMarkDown": "This field is required for a multi module project. Code coverage reports are created using ANT task. Specify source directories for code coverage reports to include highlighted source code. For example, src/java,src/Test. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html",
-            "visibleRule": "codeCoverageTool = JaCoCo"
-        },		
+	    "visibleRule": "codeCoverageTool != None"
+        },	
         {
             "name":"javaHomeSelection",
             "type":"radio",

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 19
+    "Patch": 20
   },
   "minimumAgentVersion": "1.91.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -107,7 +107,8 @@
       "helpMarkDown": "ms-resource:loc.input.help.codeCoverageTool",
       "options": {
         "None": "None",
-        "JaCoCo": "JaCoCo"
+        "JaCoCo": "JaCoCo",
+        "Cobertura": "Cobertura"
       }
     },
     {
@@ -118,7 +119,7 @@
       "required": false,
       "groupName": "codeCoverage",
       "helpMarkDown": "ms-resource:loc.input.help.classFilter",
-      "visibleRule": "codeCoverageTool = JaCoCo"
+      "visibleRule": "codeCoverageTool != None"
     },
     {
       "name": "classFilesDirectories",
@@ -137,7 +138,7 @@
       "required": false,
       "groupName": "codeCoverage",
       "helpMarkDown": "ms-resource:loc.input.help.srcDirectories",
-      "visibleRule": "codeCoverageTool = JaCoCo"
+      "visibleRule": "codeCoverageTool != None"
     },
     {
       "name": "javaHomeSelection",


### PR DESCRIPTION
Description: Currently we support only JaCoCo as Code Coverage tools for Ant and Maven tasks. This code change adds the support of using Cobertura for these tasks.

Testing: Unit Testing and Manual Testing. Functional tests pending.