### PR TITLE
Check for the local Release directory if we don't have one for Build.

### DIFF
--- a/Tasks/NugetPublisher/VsoNuGetHelper.ps1
+++ b/Tasks/NugetPublisher/VsoNuGetHelper.ps1
@@ -1,6 +1,12 @@
 Add-Type -AssemblyName System.Security
 
-$nuGetTempDirectory = Join-Path $Env:AGENT_BUILDDIRECTORY "NuGet\"
+$baseDirectory = $Env:AGENT_BUILDDIRECTORY
+if($baseDirectory -eq $null)
+{
+    $baseDirectory = $Env:AGENT_RELEASEDIRECTORY
+}
+
+$nuGetTempDirectory = Join-Path $baseDirectory "NuGet\"
 $tempNuGetConfigPath = Join-Path $nuGetTempDirectory "newNuGet.config"
 
 function SaveTempNuGetConfig


### PR DESCRIPTION
Proposed fix to address open issue of the **NuGet Publisher** task not working when ran from within a Release Definition: #745.