### PR TITLE
Reverting minimum version for agent

### DIFF
--- a/Tasks/ANT/ant.ps1
+++ b/Tasks/ANT/ant.ps1
@@ -152,7 +152,11 @@ if($publishJUnitResultsFromAntBuild)
     else
     {
         Write-Verbose "Calling Publish-TestResults"
-        Publish-TestResults -TestRunner "JUnit" -TestResultsFiles $matchingTestResultsFiles -Context $distributedTaskContext -RunTitle $testRunTitle
+		if([string]::IsNullOrEmpty($testRunTitle)) {
+			Publish-TestResults -TestRunner "JUnit" -TestResultsFiles $matchingTestResultsFiles -Context $distributedTaskContext
+		} else {
+			Publish-TestResults -TestRunner "JUnit" -TestResultsFiles $matchingTestResultsFiles -Context $distributedTaskContext -RunTitle $testRunTitle
+		}
     }    
 }
 else

--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -18,7 +18,7 @@
     "demands" : [
         "ant"
     ],
-    "minimumAgentVersion": "1.91.0",
+    "minimumAgentVersion": "1.89.0",
     "groups": [
         {
             "name":"junitTestResults",

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -21,7 +21,7 @@
   "demands": [
     "ant"
   ],
-  "minimumAgentVersion": "1.91.0",
+  "minimumAgentVersion": "1.89.0",
   "groups": [
     {
       "name": "junitTestResults",

--- a/Tasks/Gradle/Gradle.ps1
+++ b/Tasks/Gradle/Gradle.ps1
@@ -151,7 +151,12 @@ if($publishJUnitResultsFromAntBuild)
     else
     {
         Write-Verbose "Calling Publish-TestResults"
-        Publish-TestResults -TestRunner "JUnit" -TestResultsFiles $matchingTestResultsFiles -Context $distributedTaskContext -RunTitle $testRunTitle
+		if([string]::IsNullOrEmpty($testRunTitle)) {
+			Publish-TestResults -TestRunner "JUnit" -TestResultsFiles $matchingTestResultsFiles -Context $distributedTaskContext
+		} else {
+			Publish-TestResults -TestRunner "JUnit" -TestResultsFiles $matchingTestResultsFiles -Context $distributedTaskContext -RunTitle $testRunTitle
+		}
+        
     }    
 }
 else

--- a/Tasks/Gradle/task.json
+++ b/Tasks/Gradle/task.json
@@ -17,7 +17,7 @@
     "demands" : [
         "java"
     ],
-    "minimumAgentVersion": "1.91.0",
+    "minimumAgentVersion": "1.89.0",
     "groups": [
         {
             "name":"junitTestResults",

--- a/Tasks/Gradle/task.loc.json
+++ b/Tasks/Gradle/task.loc.json
@@ -20,7 +20,7 @@
   "demands": [
     "java"
   ],
-  "minimumAgentVersion": "1.91.0",
+  "minimumAgentVersion": "1.89.0",
   "groups": [
     {
       "name": "junitTestResults",

--- a/Tasks/Maven/maven.ps1
+++ b/Tasks/Maven/maven.ps1
@@ -91,7 +91,12 @@ Write-Host "Running Maven..."
 Invoke-Maven -MavenPomFile $mavenPOMFile -Options $options -Goals $goals 
 
 # Publish test results
-PublishTestResults $publishJUnitResults $testResultsFiles $testRunTitle
+if([string]::IsNullOrEmpty($testRunTitle)) {
+	PublishTestResults $publishJUnitResults $testResultsFiles
+} else {
+	PublishTestResults $publishJUnitResults $testResultsFiles $testRunTitle		
+}
+
 
 if ($codeCoverageTool.equals("JaCoCo"))
 {

--- a/Tasks/Maven/mavenHelper.ps1
+++ b/Tasks/Maven/mavenHelper.ps1
@@ -58,7 +58,12 @@ function PublishTestResults
 		else
 		{
 			Write-Verbose "Calling Publish-TestResults"
-			Publish-TestResults -TestRunner "JUnit" -TestResultsFiles $matchingTestResultsFiles -Context $distributedTaskContext -RunTitle $testRunTitle
+			if([string]::IsNullOrEmpty($testRunTitle)) {
+				Publish-TestResults -TestRunner "JUnit" -TestResultsFiles $matchingTestResultsFiles -Context $distributedTaskContext
+			} else {
+				Publish-TestResults -TestRunner "JUnit" -TestResultsFiles $matchingTestResultsFiles -Context $distributedTaskContext -RunTitle $testRunTitle
+			}
+			
 		}    
 	}
 	else

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -18,7 +18,7 @@
         "Minor": 0,
         "Patch": 20
     },
-   "minimumAgentVersion": "1.91.0",
+   "minimumAgentVersion": "1.89.0",
     "instanceNameFormat": "Maven $(mavenPOMFile)",
     "groups": [
         {

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -21,7 +21,7 @@
     "Minor": 0,
     "Patch": 20
   },
-  "minimumAgentVersion": "1.91.0",
+  "minimumAgentVersion": "1.89.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [
     {

--- a/Tasks/NuGetInstaller/VsoNuGetHelper.ps1
+++ b/Tasks/NuGetInstaller/VsoNuGetHelper.ps1
@@ -144,14 +144,15 @@ function SetCredentialsNuGetConfigAndSaveTemp
             continue
         }
 
-        if($credentialsSection.SelectSingleNode([string]$nugetSource.key) -ne $null)
+        [string]$encodedSource = [System.Xml.XmlConvert]::EncodeLocalName([string]$nugetSource.key)
+        if($credentialsSection.SelectSingleNode($encodedSource) -ne $null)
         {
-            $credentials = $credentialsSection.SelectSingleNode([string]$nugetSource.key)
+            $credentials = $credentialsSection.SelectSingleNode($encodedSource)
             foreach($section in $credentials.SelectNodes("add"))
             {
                 if([string]::Equals(([System.Xml.XmlNode]$section).Attributes["key"].Value, "password", "InvariantCultureIgnoreCase"))
                 {
-                    Write-Verbose "Setting new credential for $([string]$nugetSource.key)"
+                    Write-Verbose "Setting new credential for $encodedSource"
                     $encryptedPassword = EncryptNuGetPassword $accessToken
                     ([System.Xml.XmlNode]$section).Attributes["value"].Value = $encryptedPassword
                 }
@@ -159,8 +160,8 @@ function SetCredentialsNuGetConfigAndSaveTemp
         }
         else
         {
-            Write-Host (Get-LocalizedString -Key "Setting credentials for {0}" -ArgumentList $nugetSource.key)
-            SetNewCredentialElement $nugetConfig $credentialsSection $nugetSource.key $accessToken   
+            Write-Host (Get-LocalizedString -Key "Setting credentials for {0}" -ArgumentList $([string]$nugetSource.key))
+            SetNewCredentialElement $nugetConfig $credentialsSection $encodedSource $accessToken   
         }
     }
 

--- a/Tasks/NuGetInstaller/task.json
+++ b/Tasks/NuGetInstaller/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 15
+        "Patch": 16
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/Tasks/NuGetInstaller/task.loc.json
+++ b/Tasks/NuGetInstaller/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 15
+    "Patch": 16
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [

--- a/Tasks/NugetPublisher/VsoNuGetHelper.ps1
+++ b/Tasks/NugetPublisher/VsoNuGetHelper.ps1
@@ -144,14 +144,15 @@ function SetCredentialsNuGetConfigAndSaveTemp
             continue
         }
 
-        if($credentialsSection.SelectSingleNode([string]$nugetSource.key) -ne $null)
+        [string]$encodedSource = [System.Xml.XmlConvert]::EncodeLocalName([string]$nugetSource.key)
+        if($credentialsSection.SelectSingleNode($encodedSource) -ne $null)
         {
-            $credentials = $credentialsSection.SelectSingleNode([string]$nugetSource.key)
+            $credentials = $credentialsSection.SelectSingleNode($encodedSource)
             foreach($section in $credentials.SelectNodes("add"))
             {
                 if([string]::Equals(([System.Xml.XmlNode]$section).Attributes["key"].Value, "password", "InvariantCultureIgnoreCase"))
                 {
-                    Write-Verbose "Setting new credential for $([string]$nugetSource.key)"
+                    Write-Verbose "Setting new credential for $encodedSource"
                     $encryptedPassword = EncryptNuGetPassword $accessToken
                     ([System.Xml.XmlNode]$section).Attributes["value"].Value = $encryptedPassword
                 }
@@ -159,8 +160,8 @@ function SetCredentialsNuGetConfigAndSaveTemp
         }
         else
         {
-            Write-Host (Get-LocalizedString -Key "Setting credentials for {0}" -ArgumentList $nugetSource.key)
-            SetNewCredentialElement $nugetConfig $credentialsSection $nugetSource.key $accessToken   
+            Write-Host (Get-LocalizedString -Key "Setting credentials for {0}" -ArgumentList $([string]$nugetSource.key))
+            SetNewCredentialElement $nugetConfig $credentialsSection $encodedSource $accessToken   
         }
     }
 

--- a/Tasks/NugetPublisher/task.json
+++ b/Tasks/NugetPublisher/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 38
+        "Patch": 39
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/Tasks/NugetPublisher/task.loc.json
+++ b/Tasks/NugetPublisher/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 38
+    "Patch": 39
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [

--- a/Tasks/PublishTestResults/PublishTestResults.ps1
+++ b/Tasks/PublishTestResults/PublishTestResults.ps1
@@ -50,7 +50,11 @@ else
     $publishResultsOption = Convert-String $publishRunAttachments Boolean
     $mergeResults = Convert-String $mergeTestResults Boolean
     Write-Verbose "Calling Publish-TestResults"
-    Publish-TestResults -TestRunner $testRunner -TestResultsFiles $matchingTestResultsFiles -MergeResults $mergeResults -Platform $platform -Configuration $configuration -Context $distributedTaskContext -RunTitle $testRunTitle -PublishRunLevelAttachments $publishResultsOption
+	if([string]::IsNullOrEmpty($testRunTitle)) {
+		Publish-TestResults -TestRunner $testRunner -TestResultsFiles $matchingTestResultsFiles -MergeResults $mergeResults -Platform $platform -Configuration $configuration -Context $distributedTaskContext -PublishRunLevelAttachments $publishResultsOption
+	} else {
+		Publish-TestResults -TestRunner $testRunner -TestResultsFiles $matchingTestResultsFiles -MergeResults $mergeResults -Platform $platform -Configuration $configuration -Context $distributedTaskContext -PublishRunLevelAttachments $publishResultsOption -RunTitle $testRunTitle
+	}
 }
 
 Write-Verbose "Leaving script PublishTestResults.ps1"

--- a/Tasks/PublishTestResults/task.json
+++ b/Tasks/PublishTestResults/task.json
@@ -17,7 +17,7 @@
   },
   "demands": [ 
   ], 
-    "minimumAgentVersion": "1.91.0",
+    "minimumAgentVersion": "1.83.0",
   "groups": [
     {
       "name":"advanced",

--- a/Tasks/PublishTestResults/task.loc.json
+++ b/Tasks/PublishTestResults/task.loc.json
@@ -19,7 +19,7 @@
     "Patch": 10
   },
   "demands": [],
-  "minimumAgentVersion": "1.91.0",
+  "minimumAgentVersion": "1.83.0",
   "groups": [
     {
       "name": "advanced",


### PR DESCRIPTION
Reverting minimum version of agent required to older values.
Also, executing Publish-TestResults cmdlet with -RunTitle switch
depending upon the availability of $testRunTitle parameter.