### PR TITLE
Fixed the keystore path space issue

### DIFF
--- a/Tasks/AndroidSigning/AndroidSigning.ps1
+++ b/Tasks/AndroidSigning/AndroidSigning.ps1
@@ -137,7 +137,7 @@ foreach ($file in $filesToSign)
         # move the apk file so we do not pollute the work direcotry with multiple apks
         $unsignedApk = RenameExtension $file ".unsigned"
 
-        $jarsignerArgs = "$jarsignerArguments -keystore $keystoreFile -signedjar $file $unsignedApk $keystoreAlias"
+        $jarsignerArgs = "$jarsignerArguments -keystore `"$keystoreFile`" -signedjar $file $unsignedApk $keystoreAlias"
         
         Invoke-Tool -Path $jarsigner -Arguments $jarsignerArgs 
     }


### PR DESCRIPTION
Fixed the issue where signing would fail if the keystore path contains a white space