### PR TITLE
Porting changes for telemetry from master for Remote PowerShell Task

### DIFF
--- a/Tasks/PowerShellOnTargetMachines/PowerShellOnTargetMachines.ps1
+++ b/Tasks/PowerShellOnTargetMachines/PowerShellOnTargetMachines.ps1
@@ -26,6 +26,7 @@ Write-Verbose "initializationScriptPath = $initializationScriptPath" -Verbose
 Write-Verbose "runPowershellInParallel = $runPowershellInParallel" -Verbose
 Write-Verbose "sessionVariables = $sessionVariables" -Verbose
 
+. ./Telemetry.ps1
 . ./PowerShellJob.ps1
 
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Internal"
@@ -53,6 +54,7 @@ $ErrorActionPreference = 'Stop'
 $deploymentOperation = 'Deployment'
 
 $envOperationStatus = "Passed"
+$telemetrySet = $false
 
 # enabling detailed logging only when system.debug is true
 $enableDetailedLoggingString = $env:system_debug
@@ -97,6 +99,7 @@ function Get-ResourceWinRmConfig
     
         if([string]::IsNullOrWhiteSpace($winrmPortToUse))
         {
+            Write-Telemetry "PREREQ_NoWinRMHTTPSPort"
             throw(Get-LocalizedString -Key "{0} port was not provided for resource '{1}'" -ArgumentList "WinRM HTTPS", $resourceName)
         }
     }
@@ -110,6 +113,7 @@ function Get-ResourceWinRmConfig
     
         if([string]::IsNullOrWhiteSpace($winrmPortToUse))
         {
+            Write-Telemetry "PREREQ_NoWinRMHTTPPort"
             throw(Get-LocalizedString -Key "{0} port was not provided for resource '{1}'" -ArgumentList "WinRM HTTP", $resourceName)
         }
     }
@@ -132,6 +136,7 @@ function Get-ResourceWinRmConfig
 
                if ([string]::IsNullOrEmpty($winrmHttpPort))
                {
+                   Write-Telemetry "PREREQ_NoWinRMHTTPPort"
                    throw(Get-LocalizedString -Key "Resource: '{0}' does not have WinRM service configured. Configure WinRM service on the Azure VM Resources. Refer for more details '{1}'" -ArgumentList $resourceName, "http://aka.ms/azuresetup" )
                }
                else
@@ -166,6 +171,7 @@ function Get-ResourceWinRmConfig
 
                if ([string]::IsNullOrEmpty($winrmHttpsPort))
                {
+                   Write-Telemetry "PREREQ_NoWinRMHTTPSPort"
                    throw(Get-LocalizedString -Key "Resource: '{0}' does not have WinRM service configured. Configure WinRM service on the Azure VM Resources. Refer for more details '{1}'" -ArgumentList $resourceName, "http://aka.ms/azuresetup" )
                }
                else
@@ -256,20 +262,33 @@ function Get-ResourcesProperties
     return $resourcesPropertyBag
 }
 
-$connection = Get-VssConnection -TaskContext $distributedTaskContext
-
-Write-Verbose "Starting Register-Environment cmdlet call for environment : $environmentName with filter $machineFilter" -Verbose
-$environment = Register-Environment -EnvironmentName $environmentName -EnvironmentSpecification $environmentName -UserName $adminUserName -Password $adminPassword -WinRmProtocol $protocol -TestCertificate ($testCertificate -eq "true") -Connection $connection -TaskContext $distributedTaskContext -ResourceFilter $machineFilter
-Write-Verbose "Completed Register-Environment cmdlet call for environment : $environmentName" -Verbose
-
-Write-Verbose "Starting Get-EnvironmentResources cmdlet call on environment name: $environmentName" -Verbose
-$resources = Get-EnvironmentResources -EnvironmentName $environmentName -TaskContext $distributedTaskContext
-if ($resources.Count -eq 0)
+try
 {
-    throw (Get-LocalizedString -Key "No machine exists under environment: '{0}' for deployment" -ArgumentList $environmentName)
-}
+    $connection = Get-VssConnection -TaskContext $distributedTaskContext
 
-$resourcesPropertyBag = Get-ResourcesProperties -resources $resources
+    Write-Verbose "Starting Register-Environment cmdlet call for environment : $environmentName with filter $machineFilter" -Verbose
+    $environment = Register-Environment -EnvironmentName $environmentName -EnvironmentSpecification $environmentName -UserName $adminUserName -Password $adminPassword -WinRmProtocol $protocol -TestCertificate ($testCertificate -eq "true") -Connection $connection -TaskContext $distributedTaskContext -ResourceFilter $machineFilter
+    Write-Verbose "Completed Register-Environment cmdlet call for environment : $environmentName" -Verbose
+
+    Write-Verbose "Starting Get-EnvironmentResources cmdlet call on environment name: $environmentName" -Verbose
+    $resources = Get-EnvironmentResources -EnvironmentName $environmentName -TaskContext $distributedTaskContext
+    if ($resources.Count -eq 0)
+    {
+        Write-Telemetry "PREREQ_NoResources"
+        throw (Get-LocalizedString -Key "No machine exists under environment: '{0}' for deployment" -ArgumentList $environmentName)
+    }
+
+    $resourcesPropertyBag = Get-ResourcesProperties -resources $resources
+}
+catch
+{
+  if(-not $telemetrySet)
+  {
+    Write-Telemetry "UNKNOWNPREDEP_Error"
+  }
+
+  throw
+}
 
 if($runPowershellInParallel -eq "false" -or  ( $resources.Count -eq 1 ) )
 {
@@ -288,6 +307,7 @@ if($runPowershellInParallel -eq "false" -or  ( $resources.Count -eq 1 ) )
 
         if ($status -ne "Passed")
         {
+            Write-Telemetry "DEPLOYMENT_Failed"
             Write-Verbose $deploymentResponse.Error.ToString() -Verbose
             $errorMessage =  $deploymentResponse.Error.Message
             ThrowError -errorMessage $errorMessage
@@ -340,6 +360,7 @@ else
 
 if($envOperationStatus -ne "Passed")
 {
+    Write-Telemetry "DEPLOYMENT_Failed"
     $errorMessage = (Get-LocalizedString -Key 'Deployment on one or more machines failed.')
     ThrowError -errorMessage $errorMessage
 }

--- a/Tasks/PowerShellOnTargetMachines/Telemetry.ps1
+++ b/Tasks/PowerShellOnTargetMachines/Telemetry.ps1
@@ -1,0 +1,23 @@
+# TELEMETRY CODES
+$telemetryCodes = 
+@{"PREREQ_NoWinRMHTTP_Port" = "PREREQ001";
+  "PREREQ_NoWinRMHTTPSPort" = "PREREQ002";
+  "PREREQ_NoResources" = "PREREQ003";
+  "UNKNOWNPREDEP_Error" = "UNKNOWNPREDEP001";
+  "DEPLOYMENT_Failed" = "DEP001"
+ }
+
+# TELEMETRY FUNCTION - should we put this in agent module?
+function Write-Telemetry
+{
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory=$True,Position=1)]
+    [string]$codeKey
+    )
+
+  $code = $telemetryCodes[$codeKey]
+  $telemetryString = "##vso[task.logissue type=error;code=" + $code + ";TaskId=3B5693D4-5777-4FEE-862A-BD2B7A374C68;]"
+  Write-Host $telemetryString
+  $telemetrySet = $true
+}

--- a/Tasks/PowerShellOnTargetMachines/task.json
+++ b/Tasks/PowerShellOnTargetMachines/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 18
+    "Patch": 19
   },
   "minimumAgentVersion": "1.91.0",
   "groups": [

--- a/Tasks/PowerShellOnTargetMachines/task.loc.json
+++ b/Tasks/PowerShellOnTargetMachines/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 18
+    "Patch": 19
   },
   "minimumAgentVersion": "1.91.0",
   "groups": [


### PR DESCRIPTION
Adding a basic layered-telemetry to RemotePowerShell Task. PREDEP= pre-deployment error; DEP= error during deployment; UNKNOWNPREDEP = Unknown pre-deployment error; PREREQ = Error in prerequisite. This is followed by a numbered code distinguishing error within a category.