### PR TITLE
compat fix 

### DIFF
--- a/Tasks/ANT/ant.ps1
+++ b/Tasks/ANT/ant.ps1
@@ -184,7 +184,15 @@ if($isCoverageEnabled)
    Write-Verbose "Collecting code coverage reports" -Verbose
    try
    {
-	Invoke-Ant -AntBuildFile $reportBuildFile -Targets $CCReportTask
+	if(Test-Path $reportBuildFile)
+	{
+		# This will handle compat between S91 and S92
+		Invoke-Ant -AntBuildFile $reportBuildFile -Targets $CCReportTask
+	}
+	else
+	{
+		Invoke-Ant -AntBuildFile $antBuildFile -Targets $CCReportTask
+	}
    }
    catch
    {

--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 20
+        "Patch": 21
     },
     "demands" : [
         "ant"

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 20
+    "Patch": 21
   },
   "demands": [
     "ant"


### PR DESCRIPTION
Ant-cobertura multi module fix went in S92.
Support for Ant-cobertura single module went in S91. 
This fix will handle S91-S92 compat 

Testing done : manual testing with S91 and S92 bits.