### PR TITLE
Removing target directory generated by Cobertura

### DIFF
--- a/Tasks/Maven/maven.ps1
+++ b/Tasks/Maven/maven.ps1
@@ -70,6 +70,7 @@ $reportPOMFileName = [guid]::NewGuid().tostring() + ".xml"
 $reportPOMFile = Join-Path $buildRootPath $reportPOMFileName
 $reportDirectory = Join-Path $buildRootPath $reportDirectoryName
 $reportDirectoryCobertura = Join-Path $buildRootPath $reportDirectoryNameCobertura
+$targetDirectory = Join-Path $buildRootPath "target"
 $summaryFileNameJacoco = "jacoco.xml"
 $summaryFileNameCobertura = "coverage.xml"
 $summaryFileJacoco = Join-Path $buildRootPath $reportDirectoryName
@@ -127,6 +128,15 @@ if(Test-Path $reportPOMFile)
 {
     # delete any previous code coverage data 
     rm $reportPOMFile -force | Out-Null
+}
+
+if($isCoverageEnabled)
+{
+	if(Test-Path $targetDirectory)
+	{
+		# delete the target directory created by cobertura
+		rm -r $targetDirectory -force | Out-Null
+	}
 }
 
 # Run SonarQube analysis by invoking Maven with the "sonar:sonar" goal

--- a/Tasks/Maven/maven.ps1
+++ b/Tasks/Maven/maven.ps1
@@ -81,6 +81,15 @@ $CCReportTask = "jacoco:report"
 
 Write-Verbose "SummaryFileCobertura = $summaryFileCobertura"
 
+if($isCoverageEnabled)
+{
+	if(Test-Path $targetDirectory)
+	{
+		# delete the target directory created by cobertura
+		rm -r $targetDirectory -force | Out-Null
+	}
+}
+
 # Enable Code Coverage
 EnableCodeCoverage $isCoverageEnabled $mavenPOMFile $codeCoverageTool $classFilter $classFilesDirectories $srcDirectories $summaryFileNameJacoco $reportDirectory $reportPOMFile
 
@@ -130,14 +139,6 @@ if(Test-Path $reportPOMFile)
     rm $reportPOMFile -force | Out-Null
 }
 
-if($isCoverageEnabled)
-{
-	if(Test-Path $targetDirectory)
-	{
-		# delete the target directory created by cobertura
-		rm -r $targetDirectory -force | Out-Null
-	}
-}
 
 # Run SonarQube analysis by invoking Maven with the "sonar:sonar" goal
 RunSonarQubeAnalysis $sqAnalysisEnabled $sqConnectedServiceName $sqDbDetailsRequired $sqDbUrl $sqDbUsername $sqDbPassword $options $mavenPOMFile

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 22
+        "Patch": 23
     },
    "minimumAgentVersion": "1.91.0",
     "instanceNameFormat": "Maven $(mavenPOMFile)",
@@ -135,7 +135,7 @@
             "required": false,
             "groupName": "codeCoverage",
             "helpMarkDown": "This field is required for a multi module project. Code coverage reports are created using ANT task. Specify source directories for code coverage reports to include highlighted source code. For example, src/java,src/Test. Refer http://www.eclemma.org/jacoco/trunk/doc/ant.html",
-	    "visibleRule": "codeCoverageTool != None"
+	    "visibleRule": "codeCoverageTool = JaCoCo"
         },	
         {
             "name":"javaHomeSelection",

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 22
+    "Patch": 23
   },
   "minimumAgentVersion": "1.91.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -138,7 +138,7 @@
       "required": false,
       "groupName": "codeCoverage",
       "helpMarkDown": "ms-resource:loc.input.help.srcDirectories",
-      "visibleRule": "codeCoverageTool != None"
+      "visibleRule": "codeCoverageTool = JaCoCo"
     },
     {
       "name": "javaHomeSelection",


### PR DESCRIPTION
Description: Currently we are not deleting the target directory generated by Cobertura invocation which contains all the class files and summary files. In this case, during multiple executions of the same definition older files are picked up.

Solution: Delete the target directory after the run. This code change also makes the SorceDirectories field visibility true only for Jacoco

Testing: Manual Testing