### PR TITLE
TBSTFNP-27: The tasks escape params when invoking the msbuild scanner

### DIFF
--- a/Tasks/SonarQubePostTest/SonarQubePostTestImpl.ps1
+++ b/Tasks/SonarQubePostTest/SonarQubePostTestImpl.ps1
@@ -36,22 +36,22 @@ function GetMsBuildRunnerPostTestArgs()
 	
       if (![String]::IsNullOrWhiteSpace($serverUsername))
       {
-          [void]$sb.Append(" /d:sonar.login=""$serverUsername""")
+          [void]$sb.Append(" /d:sonar.login=" + (EscapeArg($serverUsername))) 
       }
 	  
       if (![String]::IsNullOrWhiteSpace($serverPassword))
       {
-          [void]$sb.Append(" /d:sonar.password=""$serverPassword""")
+          [void]$sb.Append(" /d:sonar.password=" + (EscapeArg($serverPassword))) 
       }
 	  
-	   if (![String]::IsNullOrWhiteSpace($dbUsername))
+	  if (![String]::IsNullOrWhiteSpace($dbUsername))
       {
-          [void]$sb.Append(" /d:sonar.jdbc.username=""$dbUsername""")
+          [void]$sb.Append(" /d:sonar.jdbc.username=" + (EscapeArg($dbUsername))) 
       }
 	  
       if (![String]::IsNullOrWhiteSpace($dbPassword))
       {
-          [void]$sb.Append(" /d:sonar.jdbc.password=""$dbPassword""")
+          [void]$sb.Append(" /d:sonar.jdbc.password=" + (EscapeArg($dbPassword))) 
       }
 
 	return $sb.ToString();
@@ -103,4 +103,16 @@ function GetTaskContextVariable()
 {
 	param([string][ValidateNotNullOrEmpty()]$varName)
 	return Get-TaskVariable -Context $distributedTaskContext -Name $varName -Global $FALSE
+}
+
+# When passing arguments to a process, the quotes need to be doubled and   
+# the entire string needs to be placed inside quotes to avoid issues with spaces  
+function EscapeArg  
+{  
+    param([string]$argVal)  
+  
+    $argVal = $argVal.Replace('"', '""');  
+    $argVal = '"' + $argVal + '"';  
+  
+    return $argVal;  
 }

--- a/Tasks/SonarQubePostTest/task.json
+++ b/Tasks/SonarQubePostTest/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 29
+        "Patch": 30
     },
     "demands": [
         "msbuild",

--- a/Tasks/SonarQubePostTest/task.loc.json
+++ b/Tasks/SonarQubePostTest/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 29
+    "Patch": 30
   },
   "demands": [
     "msbuild",

--- a/Tasks/SonarQubePreBuild/SonarQubePreBuildImpl.ps1
+++ b/Tasks/SonarQubePreBuild/SonarQubePreBuildImpl.ps1
@@ -38,43 +38,43 @@ function CreateCommandLineArgs
     # To avoid this, ignore the Append return value using [void]
     [void]$sb.Append("begin");
 
-    [void]$sb.Append(" /k:""$projectKey"" /n:""$projectName"" /v:""$projectVersion""");
+    [void]$sb.Append(" /k:" + (EscapeArg($projectKey)) + " /n:" + (EscapeArg($projectName)) + " /v:" + (EscapeArg($projectVersion)));
 
     if ([String]::IsNullOrWhiteSpace($serverUrl))
     {   
 		throw "Please setup a generic endpoint and specify the SonarQube Url as the Server Url" 
 	}
 
-	[void]$sb.Append(" /d:sonar.host.url=""$serverUrl""")
+	[void]$sb.Append(" /d:sonar.host.url=" + (EscapeArg($serverUrl))) 
 
     if (![String]::IsNullOrWhiteSpace($serverUsername))
     {
-        [void]$sb.Append(" /d:sonar.login=""$serverUsername""")
+        [void]$sb.Append(" /d:sonar.login=" + (EscapeArg($serverUsername))) 
     }
 
     if (![String]::IsNullOrWhiteSpace($serverPassword))
     {
-        [void]$sb.Append(" /d:sonar.password=""$serverPassword""")
+        [void]$sb.Append(" /d:sonar.password=" + (EscapeArg($serverPassword))) 
     }
 
     if (![String]::IsNullOrWhiteSpace($dbUrl))
     {
-        [void]$sb.Append(" /d:sonar.jdbc.url=""$dbUrl""")
+        [void]$sb.Append(" /d:sonar.jdbc.url=" + (EscapeArg($dbUrl))) 
     }
 
     if (![String]::IsNullOrWhiteSpace($dbUsername))
     {
-        [void]$sb.Append(" /d:sonar.jdbc.username=""$dbUsername""")
+        [void]$sb.Append(" /d:sonar.jdbc.username=" + (EscapeArg($dbUsername))) 
     }
 
     if (![String]::IsNullOrWhiteSpace($dbPassword))
     {
-        [void]$sb.Append(" /d:sonar.jdbc.password=""$dbPassword""")
+        [void]$sb.Append(" /d:sonar.jdbc.password=" + (EscapeArg($dbPassword))) 
     }
 
     if (![String]::IsNullOrWhiteSpace($additionalArguments))
     {
-        [void]$sb.Append(" " + $additionalArguments)
+        [void]$sb.Append(" " + $additionalArguments) # the user should take care of escaping the extra settings
     }
 
     if (IsFilePathSpecified $configFile)
@@ -84,7 +84,7 @@ function CreateCommandLineArgs
             throw "Could not find the specified configuration file: $configFile" 
         }
 
-        [void]$sb.Append(" /s:$configFile")
+        [void]$sb.Append(" /s:" + (EscapeArg($configFileParam))) 
     }
 
     return $sb.ToString();
@@ -158,6 +158,19 @@ function GetEndpointData
 
 
 ################# Helpers ######################
+
+# When passing arguments to a process, the quotes need to be doubled and   
+# the entire string needs to be placed inside quotes to avoid issues with spaces  
+function EscapeArg  
+{  
+    param([string]$argVal)  
+  
+    $argVal = $argVal.Replace('"', '""');  
+    $argVal = '"' + $argVal + '"';  
+  
+    return $argVal;  
+}  
+
 
 # Set a variable in a property bag that is accessible by all steps
 # To retrieve the variable use $val = Get-Variable $distributedTaskContext "varName"

--- a/Tasks/SonarQubePreBuild/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/SonarQubePreBuild/Strings/resources.resjson/en-US/resources.resjson
@@ -25,7 +25,7 @@
   "loc.input.label.dbPassword": "Db User Password",
   "loc.input.help.dbPassword": "SonarQube server 5.1 and lower only. The password for the database user, i.e. sonar.jdbc.password",
   "loc.input.label.cmdLineArgs": "Additional Settings",
-  "loc.input.help.cmdLineArgs": "Space separated settings using the format: /d:propertyName=propertyValue. For more details on the settings please view the [SonarQube docs](http://go.microsoft.com/fwlink/?LinkID=624390)",
+  "loc.input.help.cmdLineArgs": "Space separated settings using the format: /d:propertyName=propertyValue. Normal command line escaping rules apply. For more details on the settings please view the [SonarQube docs](http://go.microsoft.com/fwlink/?LinkID=624390).",
   "loc.input.label.configFile": "Settings File",
   "loc.input.help.configFile": "You can also specify settings via a configuration file. A template is available [here](http://go.microsoft.com/fwlink/?LinkID=620062)"
 }

--- a/Tasks/SonarQubePreBuild/task.json
+++ b/Tasks/SonarQubePreBuild/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 29
+        "Patch": 30
     },
     "demands": [
         "msbuild",

--- a/Tasks/SonarQubePreBuild/task.json
+++ b/Tasks/SonarQubePreBuild/task.json
@@ -103,7 +103,7 @@
             "type": "string",
             "label": "Additional Settings",
             "required": false,
-            "helpMarkDown": "Space separated settings using the format: /d:propertyName=propertyValue. For more details on the settings please view the [SonarQube docs](http://go.microsoft.com/fwlink/?LinkID=624390)",
+            "helpMarkDown": "Space separated settings using the format: /d:propertyName=propertyValue. Normal command line escaping rules apply. For more details on the settings please view the [SonarQube docs](http://go.microsoft.com/fwlink/?LinkID=624390).",
             "groupName": "advanced"
         },
         {

--- a/Tasks/SonarQubePreBuild/task.loc.json
+++ b/Tasks/SonarQubePreBuild/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 29
+    "Patch": 30
   },
   "demands": [
     "msbuild",


### PR DESCRIPTION
More details at: https://jira.sonarsource.com/projects/TBSTFNP/issues/TBSTFNP-27

Note: I haven't updated the actual msbuild scanner executable to 1.1 because we need to release it / sign it first. The fix won't be complete without it, but it won't break anything. 

