### PR TITLE
missing update to task.loc.json

### DIFF
--- a/Tasks/RunDistributedTests/task.loc.json
+++ b/Tasks/RunDistributedTests/task.loc.json
@@ -19,7 +19,7 @@
     "Patch": 12
   },
   "demands": [],
-  "minimumAgentVersion": "1.91.0",
+  "minimumAgentVersion": "1.88.0",
   "groups": [
     {
       "name": "setupOptions",


### PR DESCRIPTION
The revert of min agent version was missing in the task.loc.json. updated it
Part of https://github.com/Microsoft/vso-agent-tasks/pull/848 