### PR TITLE
Fix for Bug 472351 Ant Jacoco CC Report is not getting generated

### DIFF
--- a/Tasks/ANT/ant.ps1
+++ b/Tasks/ANT/ant.ps1
@@ -126,6 +126,7 @@ $CCReportTask = "CodeCoverage_" +[guid]::NewGuid()
 
 $reportBuildFileName = [guid]::NewGuid().tostring() + ".xml"
 $reportBuildFile = Join-Path $buildRootPath $reportBuildFileName
+$instrumentedClassesDirectory = Join-Path $buildRootPath "InstrumentedClasses"
 
 if($isCoverageEnabled)
 {
@@ -141,7 +142,6 @@ if($isCoverageEnabled)
 			rm -r $coberturaCCFile -force | Out-Null
 		}
 		
-		$instrumentedClassesDirectory = Join-Path $buildRootPath "InstrumentedClasses"
 		if(Test-Path $instrumentedClassesDirectory)
 		{
 			# delete any previous cobertura instrumented classes
@@ -243,6 +243,12 @@ if(Test-Path $reportBuildFile)
 {
    # delete any previous code coverage report build file
    rm -r $reportBuildFile -force | Out-Null
+}
+
+if(Test-Path $instrumentedClassesDirectory)
+{
+   # delete any previous instrumented classes directory
+   rm -r $instrumentedClassesDirectory -force | Out-Null
 }
 
 Write-Verbose "Leaving script Ant.ps1"

--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 22
+        "Patch": 23
     },
     "demands" : [
         "ant"

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 22
+    "Patch": 23
   },
   "demands": [
     "ant"


### PR DESCRIPTION
Issue : When user switched from cobertura to Jacoco coverage and user has . in classFilesDirectories.
Code coverage report generation fails as it considers instrumented classes for report generation.

Fix: deleting instrumented classes folder.

Testing : E2E testing , manual testing