### PR TITLE
Windows machine file copy readme update

### DIFF
--- a/Tasks/WindowsMachineFileCopy/README.md
+++ b/Tasks/WindowsMachineFileCopy/README.md
@@ -8,7 +8,7 @@ The task is used to copy application files and other artifacts that are required
 * **Machines**: Specify comma separated list of machine FQDNs/ip addresses along with port(optional). For example dbserver.fabrikam.com, dbserver_int.fabrikam.com:5986,192.168.34:5986. Port when not specified will be defaulted to WinRM defaults based on the specified protocol. i.e., (For *WinRM 2.0*):  The default HTTP port is 5985, and the default HTTPS port is 5986. Machines field also accepts 'Machine Groups' defined under 'Test' hub, 'Machines' tab. 
 * **Admin Login**: Domain/Local administrator of the target host. Format: &lt;Domain or hostname&gt;\ &lt; Admin User&gt;. Mandatory when used with list of machines, optional for Test Machine Group (will override test machine group value when specified). 
 * **Password**:  Password for the admin login. It can accept variable defined in Build/Release definitions as '$(passwordVariable)'. You may mark variable type as 'secret' to secure it. Mandatory when used with list of machines, optional for Test Machine Group (will override test machine group value when specified). 
-*	**Destination Folder**: The folder in the Windows machines where the files will be copied to. Environment variables are not supported.
+*	**Destination Folder**: The folder in the Windows machines where the files will be copied to. Since agent version 1.91 environment variables are no longer supported.
 *	**Clean Target**: Checking this option will clean the destination folder prior to copying the files to it.
 *	**Copy Files in Parallel**: Checking this option will copy files to all the machines in the Machine Group in-parallel, hence speeding up the process of copying.
 

--- a/Tasks/WindowsMachineFileCopy/README.md
+++ b/Tasks/WindowsMachineFileCopy/README.md
@@ -8,7 +8,7 @@ The task is used to copy application files and other artifacts that are required
 * **Machines**: Specify comma separated list of machine FQDNs/ip addresses along with port(optional). For example dbserver.fabrikam.com, dbserver_int.fabrikam.com:5986,192.168.34:5986. Port when not specified will be defaulted to WinRM defaults based on the specified protocol. i.e., (For *WinRM 2.0*):  The default HTTP port is 5985, and the default HTTPS port is 5986. Machines field also accepts 'Machine Groups' defined under 'Test' hub, 'Machines' tab. 
 * **Admin Login**: Domain/Local administrator of the target host. Format: &lt;Domain or hostname&gt;\ &lt; Admin User&gt;. Mandatory when used with list of machines, optional for Test Machine Group (will override test machine group value when specified). 
 * **Password**:  Password for the admin login. It can accept variable defined in Build/Release definitions as '$(passwordVariable)'. You may mark variable type as 'secret' to secure it. Mandatory when used with list of machines, optional for Test Machine Group (will override test machine group value when specified). 
-*	**Destination Folder**: The folder in the Windows machines where the files will be copied to. Environment variables are also supported like $env:windir, $env:systemroot etc. An example of the destination folder is $env:windir\FabrikamFibre\Web.
+*	**Destination Folder**: The folder in the Windows machines where the files will be copied to. Environment variables are not supported.
 *	**Clean Target**: Checking this option will clean the destination folder prior to copying the files to it.
 *	**Copy Files in Parallel**: Checking this option will copy files to all the machines in the Machine Group in-parallel, hence speeding up the process of copying.
 


### PR DESCRIPTION
Update the readme for the Windows machine file copy task to state that environment variables are no longer supported since agent version 1.91

Fixes #912 