### PR TITLE
Changes to XCode task to publish test results

### DIFF
--- a/Tasks/Xcode/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Xcode/Strings/resources.resjson/en-US/resources.resjson
@@ -49,6 +49,6 @@
   "loc.input.help.useXctool": "Use xctool instead of xcodebuild. Requires xctool be installed on agent hosts. See [xctool](https://github.com/facebook/xctool) for details.",
   "loc.input.label.xctoolReporter": "xctool Test Reporter Format",
   "loc.input.help.xctoolReporter": "Test reporter format to use when \"test\" action is specified and \"Use xctool\" is checked. Specify \"junit:output-file-path-here.xml\" to generate a file format compatible with the Publish Test Results task. When specified, \"plain\" is automatically added as well. Requires xctool be installed on agent hosts. See [xctool](https://github.com/facebook/xctool) for details.",
-  "loc.input.label.publishJUnitResults": "Publish to VSO/TFS",
-  "loc.input.help.publishJUnitResults": "Select this option to publish JUnit Test results produced above using xctool to VSO/TFS."
+  "loc.input.label.publishJUnitResults": "Publish to VSTS/TFS",
+  "loc.input.help.publishJUnitResults": "Select this option to publish JUnit Test results produced above using xctool to VSTS/TFS."
 }

--- a/Tasks/Xcode/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Xcode/Strings/resources.resjson/en-US/resources.resjson
@@ -48,5 +48,7 @@
   "loc.input.label.useXctool": "Use xctool",
   "loc.input.help.useXctool": "Use xctool instead of xcodebuild. Requires xctool be installed on agent hosts. See [xctool](https://github.com/facebook/xctool) for details.",
   "loc.input.label.xctoolReporter": "xctool Test Reporter Format",
-  "loc.input.help.xctoolReporter": "Test reporter format to use when \"test\" action is specified and \"Use xctool\" is checked. Specify \"junit:output-file-path-here.xml\" to generate a file format compatible with the Publish Test Results task. When specified, \"plain\" is automatically added as well. Requires xctool be installed on agent hosts. See [xctool](https://github.com/facebook/xctool) for details."
+  "loc.input.help.xctoolReporter": "Test reporter format to use when \"test\" action is specified and \"Use xctool\" is checked. Specify \"junit:output-file-path-here.xml\" to generate a file format compatible with the Publish Test Results task. When specified, \"plain\" is automatically added as well. Requires xctool be installed on agent hosts. See [xctool](https://github.com/facebook/xctool) for details.",
+  "loc.input.label.publishJUnitResults": "Publish to VSO/TFS",
+  "loc.input.help.publishJUnitResults": "Select this option to publish JUnit Test results produced above using xctool to VSO/TFS."
 }

--- a/Tasks/Xcode/task.json
+++ b/Tasks/Xcode/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 0
+        "Patch": 13
     },
     "demands" : [
         "xcode"
@@ -213,8 +213,17 @@
             "required":false,
             "helpMarkDown": "Test reporter format to use when \"test\" action is specified and \"Use xctool\" is checked. Specify \"junit:output-file-path-here.xml\" to generate a file format compatible with the Publish Test Results task. When specified, \"plain\" is automatically added as well. Requires xctool be installed on agent hosts. See [xctool](https://github.com/facebook/xctool) for details.",
             "groupName":"advanced"
+        },
+		{
+            "name":"publishJUnitResults",
+            "type":"boolean",
+            "label":"Publish to VSO/TFS",
+            "required":false,
+            "defaultValue":true,
+            "groupName":"advanced",
+            "helpMarkDown":"Select this option to publish JUnit Test results produced above using xctool to VSO/TFS."
         }
-    ],
+	],
     "execution": {
         "Node": {
             "target": "xcodebuild2.js",

--- a/Tasks/Xcode/task.json
+++ b/Tasks/Xcode/task.json
@@ -217,11 +217,11 @@
 		{
             "name":"publishJUnitResults",
             "type":"boolean",
-            "label":"Publish to VSO/TFS",
+            "label":"Publish to VSTS/TFS",
             "required":false,
-            "defaultValue":true,
+            "defaultValue":false,
             "groupName":"advanced",
-            "helpMarkDown":"Select this option to publish JUnit Test results produced above using xctool to VSO/TFS."
+            "helpMarkDown":"Select this option to publish JUnit Test results produced above using xctool to VSTS/TFS."
         }
 	],
     "execution": {

--- a/Tasks/Xcode/task.json
+++ b/Tasks/Xcode/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 13
+        "Patch": 1
     },
     "demands" : [
         "xcode"

--- a/Tasks/Xcode/task.loc.json
+++ b/Tasks/Xcode/task.loc.json
@@ -222,7 +222,7 @@
       "type": "boolean",
       "label": "ms-resource:loc.input.label.publishJUnitResults",
       "required": false,
-      "defaultValue": true,
+      "defaultValue": false,
       "groupName": "advanced",
       "helpMarkDown": "ms-resource:loc.input.help.publishJUnitResults"
     }

--- a/Tasks/Xcode/task.loc.json
+++ b/Tasks/Xcode/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 0
+    "Patch": 13
   },
   "demands": [
     "xcode"
@@ -216,6 +216,15 @@
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.xctoolReporter",
       "groupName": "advanced"
+    },
+    {
+      "name": "publishJUnitResults",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.publishJUnitResults",
+      "required": false,
+      "defaultValue": true,
+      "groupName": "advanced",
+      "helpMarkDown": "ms-resource:loc.input.help.publishJUnitResults"
     }
   ],
   "execution": {

--- a/Tasks/Xcode/task.loc.json
+++ b/Tasks/Xcode/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 13
+    "Patch": 1
   },
   "demands": [
     "xcode"

--- a/Tasks/Xcode/xcodebuild2.js
+++ b/Tasks/Xcode/xcodebuild2.js
@@ -22,15 +22,12 @@ var origXcodeDeveloperDir, out, sdk, appFolders, cwd, publishResults, testResult
 // Store original Xcode developer directory so we can restore it after build completes if its overridden
 var origXcodeDeveloperDir = process.env['DEVELOPER_DIR'];
 
-
 processInputs() 													// Process inputs to task and create xcv, xcb, import certs, profiles as required
 	.then(function(code) {
 		return xcv.exec();											// Print version of xcodebuild / xctool
 	})			
 	.then(execBuild)                                                // Run main xcodebuild / xctool task
 	.then(function(code) {                                          // publish test results
-		tl.debug('PublishTestResults : ' + publishResults);
-		tl.debug('File To Publish : ' +testResultsFiles);	
 		publishTestResults(publishResults, testResultsFiles);
 		return code;
 	})												
@@ -55,7 +52,6 @@ processInputs() 													// Process inputs to task and create xcv, xcb, impo
 	});
 
 function processInputs() {  
-	tl.debug('Processing Inputs ...');
 	// if output is rooted ($(build.buildDirectory)/output/...), will resolve to fully qualified path, 
 	// else relative to repo root
 	var buildSourceDirectory = tl.getVariable('build.sourceDirectory') || tl.getVariable('build.sourcesDirectory');

--- a/Tasks/Xcode/xcodebuild2.js
+++ b/Tasks/Xcode/xcodebuild2.js
@@ -17,7 +17,7 @@ var xcv = null,
 	deleteProvProfile = null;
 
 // Globals
-var origXcodeDeveloperDir, out, sdk, appFolders, cwd, publishResults, testResultsFiles;
+var origXcodeDeveloperDir, out, sdk, appFolders, cwd, useXctool, publishResults, testResultsFiles;
 
 // Store original Xcode developer directory so we can restore it after build completes if its overridden
 var origXcodeDeveloperDir = process.env['DEVELOPER_DIR'];
@@ -72,7 +72,7 @@ function processInputs() {
 		process.env['DEVELOPER_DIR'] = xcodeDeveloperDir;
 	}
 	// Use xctool or xccode build based on flag
-	var useXctool = (tl.getInput('useXctool', false) == "true");
+	useXctool = tl.getBoolInput('useXctool', false);
 	var tool = useXctool ? tl.which('xctool', true) : tl.which('xcodebuild', true);
 	tl.debug('Tool selected: '+ tool);
 	// Get version 
@@ -88,8 +88,16 @@ function processInputs() {
 	xcb.arg(tl.getInput('configuration', true));
 	
 	//Test Results publish inputs
-	publishResults = (tl.getInput('publishJUnitResults', true) == "true");
-    testResultsFiles = tl.getInput('xctoolReporter', false).split(":")[1].trim();
+	publishResults = tl.getBoolInput('publishJUnitResults', false);
+	var xctoolReporter = tl.getInput('xctoolReporter', false);
+	if (xctoolReporter && 0 !== xctoolReporter.length)
+	{
+		xctoolReporterString = xctoolReporter.split(":");
+		if (xctoolReporterString && xctoolReporterString.length === 2)
+		{
+			testResultsFiles = xctoolReporterString[1].trim();
+		}		 
+	}
 	
 	// Args: Add optional workspace flag
 	var workspace = tl.getPathInput('xcWorkspacePath', false, false);
@@ -121,8 +129,7 @@ function processInputs() {
 	} else {
 		tl.debug('No scheme specified in task.');
 	}
-	if(useXctool) {
-		var xctoolReporter = tl.getInput('xctoolReporter', false);
+	if(useXctool) {		
 		if(xctoolReporter) {
 			xcb.arg(['-reporter', 'plain', '-reporter', xctoolReporter])
 		}
@@ -143,7 +150,7 @@ function iosIdentity(code) {
 	
 	var input = {
 		cwd: cwd,
-		unlockDefaultKeychain: (tl.getInput('unlockDefaultKeychain', false)=="true"),
+		unlockDefaultKeychain: tl.getBoolInput('unlockDefaultKeychain', false),
 		defaultKeychainPassword: tl.getInput('defaultKeychainPassword',false),
 		p12: tl.getPathInput('p12', false, false),
 		p12pwd: tl.getInput('p12pwd', false),
@@ -170,7 +177,7 @@ function iosProfile(code) {
 		cwd: cwd,
 		provProfileUuid:tl.getInput('provProfileUuid', false),
 		provProfilePath:tl.getPathInput('provProfile', false),
-		removeProfile:(tl.getInput('removeProfile', false)=="true")
+		removeProfile:tl.getBoolInput('removeProfile', false)
 	}
 	
 	return xcutils.determineProfile(input)
@@ -196,7 +203,7 @@ function execBuild(code) {
 }
 	
 function packageApps(code) {
-	if(tl.getInput('packageApp', true) == "true" && sdk != "iphonesimulator") {
+	if(tl.getBoolInput('packageApp', true) && sdk != "iphonesimulator") {
 		tl.debug('Packaging apps.');
 		var promise = Q();
 		tl.debug('out: ' + out);
@@ -232,24 +239,31 @@ function removeExecOutputNoise(input) {
 
 function publishTestResults(publishResults, testResultsFiles) {
   if(publishResults) {
-    //check for pattern in testResultsFiles
-    if(testResultsFiles.indexOf('*') >= 0 || testResultsFiles.indexOf('?') >= 0) {
-      tl.debug('Pattern found in testResultsFiles parameter');
-      var buildFolder = tl.getVariable('agent.buildDirectory');
-      var allFiles = tl.find(buildFolder);
-      var matchingTestResultsFiles = tl.match(allFiles, testResultsFiles, { matchBase: true });
-    }
-    else {
-      tl.debug('No pattern found in testResultsFiles parameter');
-      var matchingTestResultsFiles = [testResultsFiles];
-    }
+	if (!useXctool)
+	{
+		tl.warning("Check the 'Use xctool' checkbox and specify the xctool reporter format to publish test results. No results published."); 
+		return Q(0); 		
+	}
+	if(testResultsFiles && 0 !== testResultsFiles.length) {
+		//check for pattern in testResultsFiles
+		if(testResultsFiles.indexOf('*') >= 0 || testResultsFiles.indexOf('?') >= 0) {
+			tl.debug('Pattern found in testResultsFiles parameter');
+			var buildFolder = tl.getVariable('agent.buildDirectory');
+			var allFiles = tl.find(buildFolder);
+			var matchingTestResultsFiles = tl.match(allFiles, testResultsFiles, { matchBase: true });
+		}
+		else {
+			tl.debug('No pattern found in testResultsFiles parameter');
+			var matchingTestResultsFiles = [testResultsFiles];
+		}
 
-    if(!matchingTestResultsFiles) {
-      tl.warning('No test result files matching ' + testResultsFiles + ' were found, so publishing JUnit test results is being skipped.');  
-      return Q(0);
-    }
+		if(!matchingTestResultsFiles) {
+		  tl.warning('No test result files matching ' + testResultsFiles + ' were found, so publishing JUnit test results is being skipped.');  
+		  return Q(0);
+		}
 
-    var tp = new tl.TestPublisher("JUnit");
-    tp.publish(matchingTestResultsFiles, false, "", "");
+		var tp = new tl.TestPublisher("JUnit");
+		tp.publish(matchingTestResultsFiles, false, "", "");
+	}
   }
 }


### PR DESCRIPTION
Description: Currently in the xcode task, we provide the option to run the xcode project tests and generate junit output using xctool, but this test result file is not published to TFS. If the user is specifying the output result file, we should publish it without using the Publish Results Task.

Solution: A field has been added to the task which asks the users if he/she wants to publish the test results. The generated file is published if the checkbox is checked.

Testing: Manual