### PR TITLE
fix case typo in task.json

### DIFF
--- a/Tasks/CopyPublishBuildArtifacts/task.json
+++ b/Tasks/CopyPublishBuildArtifacts/task.json
@@ -73,7 +73,7 @@
       "platforms" : ["windows"]
     },
     "Node": {
-      "target": "copyPublishBuildArtifacts.js",
+      "target": "CopyPublishBuildArtifacts.js",
       "argumentFormat": ""            
     }
   }


### PR DESCRIPTION
This case typo will resulting in failure in case sensitive system: linux, osx.