### PR TITLE
Mock getVariable call, real env variable takes precedence

### DIFF
--- a/Tests/lib/vso-task-lib/lib/sampleresponses.json
+++ b/Tests/lib/vso-task-lib/lib/sampleresponses.json
@@ -31,5 +31,9 @@
             "/some/path/one",
             "/some/path/two"        
         ]
-    } 
+    },
+    "getVariable": {
+        "someVar1": "value1",
+        "someVar2": "value2"
+    }
 }

--- a/Tests/lib/vso-task-lib/lib/vsotask.ts
+++ b/Tests/lib/vso-task-lib/lib/vsotask.ts
@@ -91,7 +91,9 @@ export function exit(code: number): void {
 export function getVariable(name: string): string {
     var varval = process.env[name.replace(/\./g, '_').toUpperCase()];
     debug(name + '=' + varval);
-    return varval;
+
+    var mocked =  mock.getResponse('getVariable', name);
+    return varval || mocked;
 }
 
 export function setVariable(name: string, val: string): void {

--- a/Tests/lib/vso-task-lib/lib/vsotask.ts
+++ b/Tests/lib/vso-task-lib/lib/vsotask.ts
@@ -93,7 +93,7 @@ export function getVariable(name: string): string {
     debug(name + '=' + varval);
 
     var mocked =  mock.getResponse('getVariable', name);
-    return varval || mocked;
+    return mocked || varval;
 }
 
 export function setVariable(name: string, val: string): void {


### PR DESCRIPTION
Mock the getVariable call.  Real environment variables take precedence so if "setVariable" is called from the task, that value is returned.