### PR TITLE
using JavaScriptSerializer instead of ConvertFrom-Json

### DIFF
--- a/Tasks/SonarQubePostTest/CodeAnalysisFilePathComputation.ps1
+++ b/Tasks/SonarQubePostTest/CodeAnalysisFilePathComputation.ps1
@@ -4,7 +4,7 @@ $ComponentKeyAndRelativePathCache = @{}
 
 function ConstructComponentKeyAndPathMap($json)
 {
-    foreach ($component in $json.Components)
+    foreach ($component in $json.components)
     {
         if (!$ComponentKeyAndPathMap.ContainsKey($component.key))
         {
@@ -155,7 +155,13 @@ function ProcessSonarCodeAnalysisReport
     $sonarReportProcessedFilePath = GetSonarReportProcessedFilePath $agentBuildDirectory
 
     #read sonar-report.json file as a json object
-    $json = Get-Content -Raw $sonarReportFilePath | ConvertFrom-Json
+    $sonarReportFileContent = Get-Content -Raw $sonarReportFilePath
+    $jsonSer = New-Object -TypeName System.Web.Script.Serialization.JavaScriptSerializer
+    
+    #default value of MaxJsonLength is 2,097,152. Increasing max length by a factor of 10 to handle bigger file sizes
+    $jsonSer.MaxJsonLength = 2097152 * 10
+    $json = $jsonSer.DeserializeObject($sonarReportFileContent)
+
     Write-Verbose "ProcessSonarCodeAnalysisReport: Total issues: $($json.issues.Count)"
 
     ConstructComponentKeyAndPathMap $json


### PR DESCRIPTION
ConvertFrom-Json uses JavaScriptSerializer internally which uses a default value of 2,097,152 for MaxJsonLength property. In some cases where the repo size is large, the sonar-report.json file size is large and ConvertFrom-Json fails to de-serialize. 
Changing the implementation to use JavaScriptSerializer class directly after increasing the limit of MaxJsonLength by a factor of 10.