### PR TITLE
Run Title and Publish Test Attachments Changes

### DIFF
--- a/Tasks/PublishTestResults/PublishTestResults.js
+++ b/Tasks/PublishTestResults/PublishTestResults.js
@@ -5,12 +5,16 @@ var testResultsFiles = tl.getInput('testResultsFiles', true);
 var mergeResults = tl.getInput('mergeTestResults');
 var platform = tl.getInput('platform');
 var config = tl.getInput('configuration');
+var testRunTitle = tl.getInput('testRunTitle');
+var publishRunAttachments = tl.getInput('publishRunAttachments');
 
 tl.debug('testRunner: ' + testRunner);
 tl.debug('testResultsFiles: ' + testResultsFiles);
 tl.debug('mergeResults: ' + mergeResults);
 tl.debug('platform: ' + platform);
 tl.debug('config: ' + config);
+tl.debug('testRunTitle: ' + testRunTitle);
+tl.debug('publishRunAttachments: ' + publishRunAttachments);
 
 //check for pattern in testResultsFiles
 if(testResultsFiles.indexOf('*') >= 0 || testResultsFiles.indexOf('?') >= 0) {
@@ -30,4 +34,4 @@ if(!matchingTestResultsFiles) {
 }
 
 var tp = new tl.TestPublisher(testRunner);
-tp.publish(matchingTestResultsFiles, mergeResults, platform, config);
+tp.publish(matchingTestResultsFiles, mergeResults, platform, config, testRunTitle, publishRunAttachments);

--- a/Tasks/PublishTestResults/task.json
+++ b/Tasks/PublishTestResults/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 13
+    "Patch": 14
   },
   "demands": [ 
   ], 

--- a/Tasks/PublishTestResults/task.loc.json
+++ b/Tasks/PublishTestResults/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 13
+    "Patch": 14
   },
   "demands": [],
   "minimumAgentVersion": "1.83.0",


### PR DESCRIPTION
Description: The PublishTestResults Task's xplat implementation is currently different from windows implementation. Users choice of Run Title and option to not publish result files do not exist in the current xplat implementation.

Solution: Changes have been made for Junit, xunit and nunit to honor users choice of run ttitle and user can now opt out of publishing test attachments.
https://github.com/Microsoft/vso-task-lib/pull/19
https://github.com/Microsoft/vso-agent/pull/168

Testing: Manual for now. Appropriate unit tests will be added if required.