### PR TITLE
Append additional arguments to RoboCopy parameters

### DIFF
--- a/Tasks/WindowsMachineFileCopy/RoboCopyJob.ps1
+++ b/Tasks/WindowsMachineFileCopy/RoboCopyJob.ps1
@@ -115,6 +115,11 @@ param (
             }
         }       
         
+        if (-not [string]::IsNullOrWhiteSpace($additionalArguments))
+        {
+            $robocopyParameters += " $additionalArguments"
+        }
+
         return $robocopyParameters.Trim()
     }
 


### PR DESCRIPTION
The WindowsMachineFileCopyTask supports passing additional arguments to
RoboCopy in RoboCopyJob.ps1. However, Get-RoboCopyParameters does nothing
with the parameter.

Update Get-RoboCopyParameters to append the additional arguments if they
are present.