### PR TITLE
Fix path.join on xplat and windows return different path separator

### DIFF
--- a/Tests/L0/AndroidSigning/androidSignAlignMultipleFile.json
+++ b/Tests/L0/AndroidSigning/androidSignAlignMultipleFile.json
@@ -19,6 +19,22 @@
         "/fake/android/home/sdk1/zipalign -v 4 /some/path/b.apk.unaligned /some/path/b.apk": {
             "code": 0,
             "stdout": "zipalign output here"
+        },
+        "\\fake\\java\\home\\bin\\jarsigner -keystore /some/store -storepass pass1 -keypass pass2 -signedjar /some/path/a.apk /some/path/a.apk.unsigned somealias": {
+            "code": 0,
+            "stdout": "jarsigner output here"
+        },
+        "\\fake\\java\\home\\bin\\jarsigner -keystore /some/store -storepass pass1 -keypass pass2 -signedjar /some/path/b.apk /some/path/b.apk.unsigned somealias": {
+            "code": 0,
+            "stdout": "jarsigner output here"
+        },
+         "\\fake\\android\\home\\sdk1\\zipalign -v 4 /some/path/a.apk.unaligned /some/path/a.apk": {
+            "code": 0,
+            "stdout": "zipalign output here"
+        },
+        "\\fake\\android\\home\\sdk1\\zipalign -v 4 /some/path/b.apk.unaligned /some/path/b.apk": {
+            "code": 0,
+            "stdout": "zipalign output here"
         }
     },
     "checkPath": {

--- a/Tests/L0/AndroidSigning/androidSignAlignSingleFile.json
+++ b/Tests/L0/AndroidSigning/androidSignAlignSingleFile.json
@@ -11,6 +11,14 @@
          "/fake/android/home/sdk1/zipalign -v 4 /some/fake.apk.unaligned /some/fake.apk": {
             "code": 0,
             "stdout": "zipalign output here"
+        },
+        "\\fake\\java\\home\\bin\\jarsigner -keystore /some/store -storepass pass1 -keypass pass2 -signedjar /some/fake.apk /some/fake.apk.unsigned somealias": {
+            "code": 0,
+            "stdout": "jarsigner output here"
+        },
+         "\\fake\\android\\home\\sdk1\\zipalign -v 4 /some/fake.apk.unaligned /some/fake.apk": {
+            "code": 0,
+            "stdout": "zipalign output here"
         }
     },
     "checkPath": {


### PR DESCRIPTION
Path.join() returns different path.separator so we should anticipate both from testing fixture.