### PR TITLE
Test-Path path type parameter fix

### DIFF
--- a/Tasks/XamarinTestCloud/XamarinTestCloud.ps1
+++ b/Tasks/XamarinTestCloud/XamarinTestCloud.ps1
@@ -115,7 +115,7 @@ if ($testCloudLocation.Contains("*") -or $testCloudLocation.Contains("?"))
 }
 else 
 {
-    if (Test-Path -Path $testCloudLocation --Type Leaf) 
+    if (Test-Path -Path $testCloudLocation -Type Leaf) 
     {
         $testCloud = $testCloudLocation 
     }


### PR DESCRIPTION
Test-Path won't accept a double dash ("--") to specify the parameter. Throws error Test-Path : A positional parameter cannot be found that accepts argument '--Type'.