### PR TITLE
make NuGetPublish work under RM as well as Build

### DIFF
--- a/Tasks/NugetPublisher/VsoNuGetHelper.ps1
+++ b/Tasks/NugetPublisher/VsoNuGetHelper.ps1
@@ -1,6 +1,9 @@
 Add-Type -AssemblyName System.Security
 
-$nuGetTempDirectory = Join-Path $Env:AGENT_BUILDDIRECTORY "NuGet\"
+# Get-TaskVariable comes from Microsoft.TeamFoundation.DistributedTask.Task.Internal and must be
+# available in the session. VsoNuGetHelper.ps1 is dotsourced into a ps1 which already imported that module.
+$artifactsDirectory = Get-TaskVariable -Context $distributedTaskContext -Name "System.ArtifactsDirectory" -Global $FALSE
+$nuGetTempDirectory = Join-Path $artifactsDirectory "NuGet\"
 $tempNuGetConfigPath = Join-Path $nuGetTempDirectory "newNuGet.config"
 
 function SaveTempNuGetConfig

--- a/Tasks/NugetPublisher/task.json
+++ b/Tasks/NugetPublisher/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 39
+        "Patch": 40
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/Tasks/NugetPublisher/task.loc.json
+++ b/Tasks/NugetPublisher/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 39
+    "Patch": 40
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [


### PR DESCRIPTION
Addresses #745. Verification I did:

* ran L0 tests  -- 60 failed, but it didn't look like any of them were related to my change and the same number fail on a fresh clone of master
* verified that the task still works in Build on VSTS
* smoke-tested that it works in Release on VSTS