### PR TITLE
Send jacocoExecpath to sonar as a parameter

### DIFF
--- a/Tasks/Maven/maven.ps1
+++ b/Tasks/Maven/maven.ps1
@@ -161,6 +161,8 @@ else
 
 if ($codeCoverageTool -eq "JaCoCo")
 {
+	#set sonar parameter
+	$execFileJacoco = Join-Path $reportDirectory "jacoco.exec"
 	# Publish code coverage for Jacoco
 	PublishCodeCoverageJacoco  $isCoverageEnabled $mavenPOMFile $CCReportTask $summaryFileJacoco $reportDirectory $codeCoverageTool $reportPOMFile
 }
@@ -171,7 +173,7 @@ ElseIf ($codeCoverageTool -eq "Cobertura")
 }
 
 # Run SonarQube analysis by invoking Maven with the "sonar:sonar" goal
-RunSonarQubeAnalysis $sqAnalysisEnabled $sqConnectedServiceName $sqDbDetailsRequired $sqDbUrl $sqDbUsername $sqDbPassword $options $mavenPOMFile
+RunSonarQubeAnalysis $sqAnalysisEnabled $sqConnectedServiceName $sqDbDetailsRequired $sqDbUrl $sqDbUsername $sqDbPassword $options $mavenPOMFile $execFileJacoco
 
 if(Test-Path $reportDirectory)
 {

--- a/Tasks/Maven/mavenHelper.ps1
+++ b/Tasks/Maven/mavenHelper.ps1
@@ -111,7 +111,7 @@ function RunSonarQubeAnalysis
 		
 		if($execFileJacoco)
 		{
-			$sqArguments = $sqArguments + " -Dsonar.jacoco.reportPath=" + '"'+ $execFileJacoco +'"'
+			$sqArguments = $sqArguments + " -Dsonar.jacoco.reportPath=" + (EscapeArg($execFileJacoco)) 
 		}
 		
 		Invoke-Maven -MavenPomFile $mavenPOMFile -Options $sqArguments -Goals "sonar:sonar"

--- a/Tasks/Maven/mavenHelper.ps1
+++ b/Tasks/Maven/mavenHelper.ps1
@@ -83,7 +83,8 @@ function RunSonarQubeAnalysis
 		  [string]$sqDbUsername,
 		  [string]$sqDbPassword, 
 		  [string]$userOptions,
-		  [string]$mavenPOMFile)
+		  [string]$mavenPOMFile,
+		  [string]$execFileJacoco)
 
 	# SonarQube Analysis - there is a known issue with the SonarQube Maven plugin that the sonar:sonar goal should be run independently
 	$sqAnalysisEnabledBool = Convert-String $sqAnalysisEnabled Boolean
@@ -104,10 +105,15 @@ function RunSonarQubeAnalysis
 			# The platform may cache the db details values so we force them to be empty
 			$sqArguments = CreateSonarQubeArgs $sqServiceEndpoint.Url $sqServiceEndpoint.Authorization.Parameters.UserName $sqServiceEndpoint.Authorization.Parameters.Password "" "" ""
 		}
-
+		
 		$sqArguments = $userOptions + " " + $sqArguments
 		Write-Verbose "Running Maven with goal sonar:sonar and options: $sqArguments"
-
+		
+		if($execFileJacoco)
+		{
+			$sqArguments = $sqArguments + " -Dsonar.jacoco.reportPath=" + $execFileJacoco			
+		}
+		
 		Invoke-Maven -MavenPomFile $mavenPOMFile -Options $sqArguments -Goals "sonar:sonar"
 	 }
 }

--- a/Tasks/Maven/mavenHelper.ps1
+++ b/Tasks/Maven/mavenHelper.ps1
@@ -111,7 +111,7 @@ function RunSonarQubeAnalysis
 		
 		if($execFileJacoco)
 		{
-			$sqArguments = $sqArguments + " -Dsonar.jacoco.reportPath=" + $execFileJacoco			
+			$sqArguments = $sqArguments + " -Dsonar.jacoco.reportPath=" + '"'+ $execFileJacoco +'"'
 		}
 		
 		Invoke-Maven -MavenPomFile $mavenPOMFile -Options $sqArguments -Goals "sonar:sonar"

--- a/Tasks/Maven/task.json
+++ b/Tasks/Maven/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 29
+        "Patch": 30
     },
    "minimumAgentVersion": "1.89.0",
     "instanceNameFormat": "Maven $(mavenPOMFile)",

--- a/Tasks/Maven/task.loc.json
+++ b/Tasks/Maven/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 29
+    "Patch": 30
   },
   "minimumAgentVersion": "1.89.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
Testing done: Verified with/without code coverage tool, Cobertura, jacoco. If the options already have the property.
