### PR TITLE
Fixed mis-spelled variable in xcodepkgios.ts

### DIFF
--- a/Tasks/XcodePackageiOS/xcodepkgios.ts
+++ b/Tasks/XcodePackageiOS/xcodepkgios.ts
@@ -3,7 +3,7 @@
 import tl = require('vsts-task-lib/task');
 import path = require('path');
 
-var sourceDir = tl.getVariable('build.sourceDirectory');
+var sourceDir = tl.getVariable('build.sourcesDirectory');
 
 var tool = tl.which('xcrun', true);
 var xcv = tl.createToolRunner(tool);


### PR DESCRIPTION
build.sourceDirectory doesn't exist. Should be build.sourcesDirectory