### PR TITLE
PowerShell task now supports inline scripting

### DIFF
--- a/Tasks/powerShell/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/powerShell/Strings/resources.resjson/en-US/resources.resjson
@@ -7,10 +7,14 @@
   "loc.description": "Run a PowerShell script",
   "loc.instanceNameFormat": "Powershell: $(scriptName)",
   "loc.group.displayName.advanced": "Advanced",
+  "loc.input.label.type": "Type",
+  "loc.input.help.type": "File Path or Inline Script",
   "loc.input.label.scriptName": "Script filename",
   "loc.input.help.scriptName": "Path of the script to execute. Should be fully qualified path or relative to the default working directory.",
   "loc.input.label.arguments": "Arguments",
   "loc.input.help.arguments": "Arguments passed to the PowerShell script.  Either ordinal parameters or named parameters",
   "loc.input.label.workingFolder": "Working folder",
-  "loc.input.help.workingFolder": "Current working directory when script is run.  Defaults to the folder where the script is located."
+  "loc.input.help.workingFolder": "Current working directory when script is run.  Defaults to the folder where the script is located.",
+  "loc.input.label.script": "Script",
+  "loc.input.help.script": "Write your scripts and have fun"
 }

--- a/Tasks/powerShell/powershell.ps1
+++ b/Tasks/powerShell/powershell.ps1
@@ -1,0 +1,33 @@
+param (
+[string] $type,
+[string] $scriptName,
+[string] $arguments,
+[string] $workingFolder,
+[string] $script
+)
+
+Write-Verbose 'Entering powershell.ps1'
+Write-Verbose 'Current Working Directory is $cwd'
+Write-Host "Here I am "
+Write-Host "Type is" $type
+Write-Host "ScriptName is" $scriptName
+Write-Host "args are" $arguments
+Write-Host "Working folder is" $workingFolder
+Write-Host "Script is " $script
+
+if($workingFolder)
+{
+    if(!(Test-Path $workingFolder -PathType Container))
+    {
+        throw ("$workingFolder does not exist");
+    }
+    Write-Verbose "Setting working directory to $workingFolder"
+    Set-Location $workingFolder
+}
+
+if($type -eq "InlineScript"){
+    Invoke-Expression $script
+}else{
+    # Default is FilePath
+    Invoke-Expression "& `"$scriptName`" $arguments"
+}

--- a/Tasks/powerShell/task.json
+++ b/Tasks/powerShell/task.json
@@ -11,9 +11,9 @@
                   ],    
     "author": "Microsoft Corporation",
     "version": {
-        "Major": 1,
+        "Major": 2,
         "Minor": 0,
-        "Patch": 5
+        "Patch": 0
     },
     "demands": [
         "DotNetFramework"
@@ -26,13 +26,26 @@
         }
     ],
     "inputs": [
+        {
+            "name": "type",
+            "type": "pickList",
+            "label": "Type",
+            "defaultValue": "FilePath",
+            "required": true,
+            "helpMarkDown": "File Path or Inline Script",
+            "options": {
+                "InlineScript": "Inline Script",
+                "FilePath": "File Path"
+            }
+        },
         { 
             "name": "scriptName", 
             "type": "filePath", 
             "label": "Script filename", 
             "defaultValue":"", 
             "required":true,
-            "helpMarkDown": "Path of the script to execute. Should be fully qualified path or relative to the default working directory." 
+            "helpMarkDown": "Path of the script to execute. Should be fully qualified path or relative to the default working directory.",
+            "visibleRule": "type = FilePath"
         },
         { 
             "name": "arguments", 
@@ -40,7 +53,8 @@
             "label": "Arguments", 
             "defaultValue":"", 
             "required":false,
-            "helpMarkDown": "Arguments passed to the PowerShell script.  Either ordinal parameters or named parameters" 
+            "helpMarkDown": "Arguments passed to the PowerShell script.  Either ordinal parameters or named parameters",
+            "visibleRule": "type = FilePath"
         },
         { 
             "name": "workingFolder", 
@@ -50,13 +64,25 @@
             "required":false,
             "helpMarkDown": "Current working directory when script is run.  Defaults to the folder where the script is located.",
             "groupName":"advanced"
+        },
+        {
+            "name": "script",
+            "type": "multiLine",
+            "label": "Script",
+            "defaultValue": "Write-Host 'Hello World'",
+            "required": true,
+            "helpMarkDown": "Write your scripts and have fun",
+            "visibleRule": "type = InlineScript",
+            "properties": {
+                "rows": 5
+            }
         }
     ],
     "instanceNameFormat": "Powershell: $(scriptName)",
     "execution": {
-        "PowerShellExe": {
-            "target": "$(scriptName)",
-            "argumentFormat": "$(arguments)",
+        "PowerShell": {
+            "target": "$(currentDirectory)\\powershell.ps1",
+            "argumentFormat": "",
             "workingDirectory": "$(workingFolder)"
         }
     }

--- a/Tasks/powerShell/task.loc.json
+++ b/Tasks/powerShell/task.loc.json
@@ -14,9 +14,9 @@
   ],
   "author": "Microsoft Corporation",
   "version": {
-    "Major": 1,
+    "Major": 2,
     "Minor": 0,
-    "Patch": 5
+    "Patch": 0
   },
   "demands": [
     "DotNetFramework"
@@ -30,12 +30,25 @@
   ],
   "inputs": [
     {
+      "name": "type",
+      "type": "pickList",
+      "label": "ms-resource:loc.input.label.type",
+      "defaultValue": "FilePath",
+      "required": true,
+      "helpMarkDown": "ms-resource:loc.input.help.type",
+      "options": {
+        "InlineScript": "Inline Script",
+        "FilePath": "File Path"
+      }
+    },
+    {
       "name": "scriptName",
       "type": "filePath",
       "label": "ms-resource:loc.input.label.scriptName",
       "defaultValue": "",
       "required": true,
-      "helpMarkDown": "ms-resource:loc.input.help.scriptName"
+      "helpMarkDown": "ms-resource:loc.input.help.scriptName",
+      "visibleRule": "type = FilePath"
     },
     {
       "name": "arguments",
@@ -43,7 +56,8 @@
       "label": "ms-resource:loc.input.label.arguments",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "ms-resource:loc.input.help.arguments"
+      "helpMarkDown": "ms-resource:loc.input.help.arguments",
+      "visibleRule": "type = FilePath"
     },
     {
       "name": "workingFolder",
@@ -53,13 +67,25 @@
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.workingFolder",
       "groupName": "advanced"
+    },
+    {
+      "name": "script",
+      "type": "multiLine",
+      "label": "ms-resource:loc.input.label.script",
+      "defaultValue": "Write-Host 'Hello World'",
+      "required": true,
+      "helpMarkDown": "ms-resource:loc.input.help.script",
+      "visibleRule": "type = InlineScript",
+      "properties": {
+        "rows": 5
+      }
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "execution": {
-    "PowerShellExe": {
-      "target": "$(scriptName)",
-      "argumentFormat": "$(arguments)",
+    "PowerShell": {
+      "target": "$(currentDirectory)\\powershell.ps1",
+      "argumentFormat": "",
       "workingDirectory": "$(workingFolder)"
     }
   }


### PR DESCRIPTION
Powershell task now supports inline scripting. 

This task is backward compatible with the existing build definitions and release definition.

Also a new property rows is added which will allow to control the height of a multiline input