### PR TITLE
ignore NuGet.exe extensions when using built-in nuget

### DIFF
--- a/Tasks/NuGetInstaller/task.json
+++ b/Tasks/NuGetInstaller/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 16
+        "Patch": 17
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/Tasks/NuGetInstaller/task.loc.json
+++ b/Tasks/NuGetInstaller/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 16
+    "Patch": 17
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [

--- a/Tasks/NugetPackager/NuGetPackager.ps1
+++ b/Tasks/NugetPackager/NuGetPackager.ps1
@@ -101,44 +101,65 @@ foreach ($fileToPackage in $foundFiles)
     Write-Host "--File: `"$fileToPackage`""
 }
 
-foreach ($fileToPackage in $foundFiles)
+$useBuiltinNuGetExe = !$nuGetPath
+
+if($useBuiltinNuGetExe)
 {
-    $slnFolder = $(Get-ItemProperty -Path $fileToPackage -Name 'DirectoryName').DirectoryName
-    #Setup Nuget
-    Write-Host "Creating Nuget Arguments:"
-    $buildProps = "Configuration=$configurationToPack";
-    if ([string]::IsNullOrEmpty($buildProperties) -eq $false)
-    {
-        $buildProps = ($buildProps + ";" + $buildProperties)
-    }
-    $argsPack = "pack `"$fileToPackage`" -OutputDirectory `"$outputdir`" -Properties $buildProps";
-    
-    if ($b_versionByBuild)
-    {
-        $argsPack = ($argsPack + " -version $NewVersion")
-    }
-    if($nuGetAdditionalArgs)
-    {
-        $argsPack = ($argsPack + " " + $nuGetAdditionalArgs);
-    }    
-     
-    Write-Host "--ARGS: $argsPack"
-    
-    if(!$nuGetPath)
-    {
-        $nuGetPath = Get-ToolPath -Name 'NuGet.exe';
-    }
-    
-    if (-not $nuGetPath)
-    {
-        throw (Get-LocalizedString -Key "Unable to locate {0}" -ArgumentList 'nuget.exe')
-    }
-    
+    $nuGetPath = Get-ToolPath -Name 'NuGet.exe';
+}
+
+if (-not $nuGetPath)
+{
+    throw (Get-LocalizedString -Key "Unable to locate {0}" -ArgumentList 'nuget.exe')
+}
+
+$initialNuGetExtensionsPath = $env:NUGET_EXTENSIONS_PATH
+try
+{
     if ($env:NUGET_EXTENSIONS_PATH)
     {
-        Write-Host (Get-LocalizedString -Key "Detected NuGet extensions loader path. Environment variable NUGET_EXTENSIONS_PATH is set to: {0}" -ArgumentList $env:NUGET_EXTENSIONS_PATH)
+        if($useBuiltinNuGetExe)
+        {
+            # NuGet.exe extensions only work with a single specific version of nuget.exe. This causes problems
+            # whenever we update nuget.exe on the agent.
+            $env:NUGET_EXTENSIONS_PATH = $null
+            Write-Warning (Get-LocalizedString -Key "The NUGET_EXTENSIONS_PATH environment variable is set, but nuget.exe extensions are not supported when using the built-in NuGet implementation.")   
+        }
+        else
+        {
+            Write-Host (Get-LocalizedString -Key "Detected NuGet extensions loader path. Environment variable NUGET_EXTENSIONS_PATH is set to: {0}" -ArgumentList $env:NUGET_EXTENSIONS_PATH)
+        }
     }
 
-    Write-Host "Invoking nuget with $argsPack on $slnFolder"
-    Invoke-Tool -Path $nugetPath -Arguments "$argsPack" -WorkingFolder $slnFolder
+    foreach ($fileToPackage in $foundFiles)
+    {
+        $slnFolder = $(Get-ItemProperty -Path $fileToPackage -Name 'DirectoryName').DirectoryName
+        #Setup Nuget
+        Write-Host "Creating Nuget Arguments:"
+        $buildProps = "Configuration=$configurationToPack";
+        if ([string]::IsNullOrEmpty($buildProperties) -eq $false)
+        {
+            $buildProps = ($buildProps + ";" + $buildProperties)
+        }
+        $argsPack = "pack `"$fileToPackage`" -OutputDirectory `"$outputdir`" -Properties $buildProps";
+        
+        if ($b_versionByBuild)
+        {
+            $argsPack = ($argsPack + " -version $NewVersion")
+        }
+        if($nuGetAdditionalArgs)
+        {
+            $argsPack = ($argsPack + " " + $nuGetAdditionalArgs);
+        }    
+         
+        Write-Host "--ARGS: $argsPack"
+
+        Write-Host "Invoking nuget with $argsPack on $slnFolder"
+        Invoke-Tool -Path $nugetPath -Arguments "$argsPack" -WorkingFolder $slnFolder
+    }
 }
+finally
+{
+    $env:NUGET_EXTENSIONS_PATH = $initialNuGetExtensionsPath
+}
+

--- a/Tasks/NugetPackager/task.json
+++ b/Tasks/NugetPackager/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 57
+        "Patch": 58
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/Tasks/NugetPackager/task.loc.json
+++ b/Tasks/NugetPackager/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 57
+    "Patch": 58
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [

--- a/Tasks/NugetPublisher/task.json
+++ b/Tasks/NugetPublisher/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 42
+        "Patch": 43
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/Tasks/NugetPublisher/task.loc.json
+++ b/Tasks/NugetPublisher/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 42
+    "Patch": 43
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [


### PR DESCRIPTION
NuGet.exe extensions only work with a single specific version of nuget.exe. This causes problems whenever we update NuGet on the agent.