### PR TITLE
Adding DatasourceBindings instead of sourceDefinition in tasks

### DIFF
--- a/Tasks/AzureFileCopy/task.json
+++ b/Tasks/AzureFileCopy/task.json
@@ -237,8 +237,8 @@
     {
       "target": "EnvironmentNameRM",
       "endpointId": "$(ConnectedServiceNameARM)",
-      "dataSourceName": "AzureVirtualMachinesV2Details",
-      "resultTemplate": "{{#extractResourceGroup id}}"
+      "dataSourceName": "AzureVirtualMachinesV2Id",
+      "resultTemplate": "{{#extractResource resourceGroups}}"
     }
   ],
   "instanceNameFormat": "$(Destination) File Copy",

--- a/Tasks/AzureFileCopy/task.json
+++ b/Tasks/AzureFileCopy/task.json
@@ -18,7 +18,7 @@
   "demands": [
     "azureps"
   ],
-  "minimumAgentVersion": "1.95.0",
+  "minimumAgentVersion": "1.94.0",
   "inputs": [
     {
       "name": "SourcePath",
@@ -228,20 +228,17 @@
       "target": "EnvironmentName",
       "endpointId": "$(ConnectedServiceName)",
       "dataSourceName": "AzureHostedServiceNames"
-    }
-  ],
-  "sourceDefinitions": [
+    },
     {
       "target": "StorageAccountRM",
-      "endpoint": "https://management.azure.com/subscriptions/$(authKey.SubscriptionId)/providers/Microsoft.Storage/storageAccounts?api-version=2015-06-15",
-      "selector": "jsonpath:$.value[*].name",
-      "authKey": "$(ConnectedServiceNameARM)"
+      "endpointId": "$(ConnectedServiceNameARM)",
+      "dataSourceName": "AzureStorageAccountRM"
     },
     {
       "target": "EnvironmentNameRM",
-      "endpoint": "https://management.azure.com/subscriptions/$(authKey.SubscriptionId)/resourcegroups?api-version=2015-01-01",
-      "selector": "jsonpath:$.value[*].name",
-      "authKey": "$(ConnectedServiceNameARM)"
+      "endpointId": "$(ConnectedServiceNameARM)",
+      "dataSourceName": "AzureVirtualMachinesV2Details",
+      "resultTemplate": "{{#extractResourceGroup id}}"
     }
   ],
   "instanceNameFormat": "$(Destination) File Copy",

--- a/Tasks/AzureFileCopy/task.loc.json
+++ b/Tasks/AzureFileCopy/task.loc.json
@@ -21,7 +21,7 @@
   "demands": [
     "azureps"
   ],
-  "minimumAgentVersion": "1.95.0",
+  "minimumAgentVersion": "1.94.0",
   "inputs": [
     {
       "name": "SourcePath",
@@ -231,20 +231,17 @@
       "target": "EnvironmentName",
       "endpointId": "$(ConnectedServiceName)",
       "dataSourceName": "AzureHostedServiceNames"
-    }
-  ],
-  "sourceDefinitions": [
+    },
     {
       "target": "StorageAccountRM",
-      "endpoint": "https://management.azure.com/subscriptions/$(authKey.SubscriptionId)/providers/Microsoft.Storage/storageAccounts?api-version=2015-06-15",
-      "selector": "jsonpath:$.value[*].name",
-      "authKey": "$(ConnectedServiceNameARM)"
+      "endpointId": "$(ConnectedServiceNameARM)",
+      "dataSourceName": "AzureStorageAccountRM"
     },
     {
       "target": "EnvironmentNameRM",
-      "endpoint": "https://management.azure.com/subscriptions/$(authKey.SubscriptionId)/resourcegroups?api-version=2015-01-01",
-      "selector": "jsonpath:$.value[*].name",
-      "authKey": "$(ConnectedServiceNameARM)"
+      "endpointId": "$(ConnectedServiceNameARM)",
+      "dataSourceName": "AzureVirtualMachinesV2Details",
+      "resultTemplate": "{{#extractResourceGroup id}}"
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/AzureFileCopy/task.loc.json
+++ b/Tasks/AzureFileCopy/task.loc.json
@@ -240,8 +240,8 @@
     {
       "target": "EnvironmentNameRM",
       "endpointId": "$(ConnectedServiceNameARM)",
-      "dataSourceName": "AzureVirtualMachinesV2Details",
-      "resultTemplate": "{{#extractResourceGroup id}}"
+      "dataSourceName": "AzureVirtualMachinesV2Id",
+      "resultTemplate": "{{#extractResource resourceGroups}}"
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/AzurePowerShell/task.json
+++ b/Tasks/AzurePowerShell/task.json
@@ -18,7 +18,7 @@
     "demands" : [
         "azureps"
     ],
-    "minimumAgentVersion": "1.95.0",
+    "minimumAgentVersion": "1.94.0",
     "inputs": [
         {
             "name": "ConnectedServiceNameSelector",

--- a/Tasks/AzurePowerShell/task.loc.json
+++ b/Tasks/AzurePowerShell/task.loc.json
@@ -21,7 +21,7 @@
   "demands": [
     "azureps"
   ],
-  "minimumAgentVersion": "1.95.0",
+  "minimumAgentVersion": "1.94.0",
   "inputs": [
     {
       "name": "ConnectedServiceNameSelector",

--- a/Tasks/DeployAzureResourceGroup/task.json
+++ b/Tasks/DeployAzureResourceGroup/task.json
@@ -196,8 +196,8 @@
     {
       "target": "resourceGroupName",
       "endpointId": "$(ConnectedServiceName)",
-      "dataSourceName": "AzureVirtualMachinesV2Details",
-      "resultTemplate": "{{#extractResourceGroup id}}"
+      "dataSourceName": "AzureVirtualMachinesV2Id",
+      "resultTemplate": "{{#extractResource resourceGroups}}"
     }
   ],
   "instanceNameFormat": "Azure Deployment:$(action) action on $(resourceGroupName)",

--- a/Tasks/DeployAzureResourceGroup/task.json
+++ b/Tasks/DeployAzureResourceGroup/task.json
@@ -1,208 +1,206 @@
 {
-    "id": "94A74903-F93F-4075-884F-DC11F34058B4",
-    "name": "AzureResourceGroupDeployment",
-    "friendlyName": "Azure Resource Group Deployment",
-    "description": "Deploy, start, stop, delete Azure Resource Groups",
-    "helpMarkDown": "[More Information](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployAzureResourceGroup/README.md)",
-    "category": "Deploy",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
-    "author": "Microsoft Corporation",
-    "version": {
-        "Major": 1,
-        "Minor": 0,
-        "Patch": 52
+  "id": "94A74903-F93F-4075-884F-DC11F34058B4",
+  "name": "AzureResourceGroupDeployment",
+  "friendlyName": "Azure Resource Group Deployment",
+  "description": "Deploy, start, stop, delete Azure Resource Groups",
+  "helpMarkDown": "[More Information](https://github.com/Microsoft/vso-agent-tasks/blob/master/Tasks/DeployAzureResourceGroup/README.md)",
+  "category": "Deploy",
+  "visibility": [
+    "Build",
+    "Release"
+  ],
+  "author": "Microsoft Corporation",
+  "version": {
+    "Major": 1,
+    "Minor": 0,
+    "Patch": 52
+  },
+  "demands": [
+    "azureps"
+  ],
+  "minimumAgentVersion": "1.94.0",
+  "groups": [
+    {
+      "name": "output",
+      "displayName": "Output",
+      "isExpanded": true
+    }
+  ],
+  "inputs": [
+    {
+      "name": "ConnectedServiceNameSelector",
+      "type": "pickList",
+      "label": "Azure Connection Type",
+      "required": false,
+      "helpMarkDown": "",
+      "defaultValue": "ConnectedServiceName",
+      "options": {
+        "ConnectedServiceName": "Azure Resource Manager",
+        "ConnectedServiceNameClassic": "Azure Classic"
+      }
     },
-    "demands": [
-        "azureps"
-    ],
-    "minimumAgentVersion": "1.95.0",
-    "groups": [
-        {
-            "name": "output",
-            "displayName": "Output",
-            "isExpanded": true
-        }
-    ],
-    "inputs": [
-        {
-            "name": "ConnectedServiceNameSelector",
-            "type": "pickList",
-            "label": "Azure Connection Type",
-            "required": false,
-            "helpMarkDown": "",
-            "defaultValue": "ConnectedServiceName",
-            "options": {
-                "ConnectedServiceName": "Azure Resource Manager",
-                "ConnectedServiceNameClassic": "Azure Classic"
-            }
-        },
-        {
-            "name": "ConnectedServiceName",
-            "type": "connectedService:AzureRM",
-            "label": "Azure RM Subscription",
-            "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "Select the Azure Resource Manager subscription for the deployment.",
-            "visibleRule": "ConnectedServiceNameSelector = ConnectedServiceName"
-        },
-        {
-            "name": "ConnectedServiceNameClassic",
-            "type": "connectedService:Azure",
-            "label": "Classic Azure Subscription",
-            "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "Select the Classic Azure subscription for the deployment.",
-            "visibleRule": "ConnectedServiceNameSelector = ConnectedServiceNameClassic"
-        },
-        {
-            "name": "action", 
-            "type": "pickList", 
-            "label": "Action",
-            "defaultValue": "Create Or Update Resource Group",
-            "required": true,
-            "helpMarkDown" : "Action to be performed on the Azure resources or resource group.",
-            "options": {
-                 "Create Or Update Resource Group": "Create Or Update Resource Group",
-                 "Select Resource Group": "Select Resource Group",
-                 "Start": "Start Virtual Machines",
-                 "Stop": "Stop Virtual Machines",
-                 "Restart": "Restart Virtual Machines",
-                 "Delete": "Delete Virtual Machines",
-                 "DeleteRG": "Delete Resource Group"
-                },
-            "visibleRule": "ConnectedServiceNameSelector = ConnectedServiceName"
-        },
-        {
-            "name": "actionClassic", 
-            "type": "pickList", 
-            "label": "Action",
-            "defaultValue": "Select Resource Group",
-            "required": true,
-            "helpMarkDown" : "Action to be performed on the Azure resources or cloud service.",
-            "options": {
-                 "Select Resource Group": "Select Cloud Service"
-                },
-            "visibleRule": "ConnectedServiceNameSelector = ConnectedServiceNameClassic"
-        },
-        {
-            "name": "resourceGroupName",
-            "type": "pickList",
-            "label": "Resource Group",
-            "required": true,
-            "helpMarkDown": "Provide the name of the resource group.",
-            "visibleRule": "ConnectedServiceNameSelector = ConnectedServiceName"
-        },
-        {
-            "name": "cloudService",
-            "type": "pickList",
-            "label": "Cloud Service",
-            "required": true,
-            "helpMarkDown": "Provide the name of the cloud service.",
-            "visibleRule": "ConnectedServiceNameSelector = ConnectedServiceNameClassic"
-        },
-        {
-            "name": "location",
-            "type": "pickList",
-            "label": "Location",
-            "defaultValue": "East US",
-            "required": true,
-            "helpMarkDown": "Location for deploying the resource group. If the resource group already exists in the subscription, then this value will be ignored.",
-            "options": {
-                "Australia East": "Australia East",
-                "Australia Southeast": "Australia Southeast",
-                "Brazil South": "Brazil South",
-                "Central US": "Central US",
-                "East Asia": "East Asia",
-                "East US": "East US",
-                "East US 2 ": "East US 2 ",
-                "Japan East": "Japan East",
-                "Japan West": "Japan West",
-                "North Central US": "North Central US",
-                "North Europe": "North Europe",
-                "South Central US": "South Central US",
-                "Southeast Asia": "Southeast Asia",
-                "West Europe": "West Europe",
-                "West US": "West US"
-            },
-            "properties": {
-                "EditableOptions": "True" 
-            },
-            "visibleRule": "action = Create Or Update Resource Group"
-        },
-        {
-            "name": "csmFile", 
-            "type": "filePath", 
-            "label": "Template", 
-            "defaultValue":"",
-            "required": true,
-            "helpMarkDown": "Specify the path to the Azure Resource Manager template. For more information about the templates see http://aka.ms/azuretemplates. To get started immediately use template http://aka.ms/sampletemplate.",
-            "visibleRule": "action = Create Or Update Resource Group"
-        },
-        {
-            "name": "csmParametersFile",
-            "type": "filePath",
-            "label": "Template Parameters",
-            "defaultValue": "",
-            "required": false,
-            "helpMarkDown": "Specify the path for the parameters file for the Azure Resource Manager Template.",
-            "visibleRule": "action = Create Or Update Resource Group"
-        },
-        {
-            "name": "overrideParameters",
-            "type": "multiLine",
-            "label": "Override Template Parameters",
-            "defaultValue": "",
-            "required": false,
-            "helpMarkDown": "Specify the template parameters to override like, <br>–storageName fabrikam –adminUsername $(vmusername) -adminPassword (ConvertTo-SecureString -String '$(password)' -AsPlainText -Force) –azureKeyVaultName $(fabrikamFibre).",
-            "visibleRule": "action = Create Or Update Resource Group"
-        },
-        {
-            "name": "enableDeploymentPrerequisitesForCreate",
-            "type": "boolean",
-            "label": "Enable Deployment Prerequisites",
-            "defaultValue": "false",
-            "visibleRule": "action = Create Or Update Resource Group",
-            "required": false,
-            "helpMarkDown": "Enabling this option configures Windows Remote Management (WinRM) listener over HTTPS protocol on port 5986, using a self-signed certificate. This configuration is required for performing deployment operation on Azure machines. If the target Virtual Machines are backed by a Load balancer, ensure Inbound NAT rules are configured for target port (5986). If the target Virtual Machines are associated with a Network security group (NSG), configure Inbound security rules for Destination port (5986)."
-        },
-        {
-            "name": "enableDeploymentPrerequisitesForSelect",
-            "type": "boolean",
-            "label": "Enable Deployment Prerequisites",
-            "defaultValue": "false",
-            "visibleRule": "action = Select Resource Group",
-            "required": false,
-            "helpMarkDown": "Enabling this option configures Windows Remote Management (WinRM) listener over HTTPS protocol on port 5986, using a self-signed certificate. This configuration is required for performing deployment operation on Azure machines. If the target Virtual Machines are backed by a Load balancer, ensure Inbound NAT rules are configured for target port (5986). If the target Virtual Machines are associated with a Network security group (NSG), configure Inbound security rules for Destination port (5986). Applicable only for ARM VMs."
-        },
-        {
-            "name": "outputVariable",
-            "type": "string",
-            "label": "Resource Group",
-            "required": false,
-            "defaultValue": "",
-            "groupName": "output",
-            "helpMarkDown": "Provide a name for the variable for the resource group. The variable can be used as $(variableName) to refer to the resource group in subsequent tasks like in the PowerShell on Target Machines task for deploying applications. <br>Valid only when the selected action is Create, Update or Select, and required when an existing resource group is selected."
-        }
-    ],
-    "dataSourceBindings": [
-        {
-            "target": "cloudService",
-            "endpointId": "$(ConnectedServiceNameClassic)",
-            "dataSourceName": "AzureHostedServiceNames"
-        }
-    ],
-    "sourceDefinitions": [
-        {
-            "target": "resourceGroupName",
-            "endpoint": "https://management.azure.com/subscriptions/$(authKey.SubscriptionId)/resourcegroups?api-version=2015-01-01",
-            "selector": "jsonpath:$.value[*].name",
-            "authKey": "$(ConnectedServiceName)"
-        }
-    ],
-    "instanceNameFormat": "Azure Deployment:$(action) action on $(resourceGroupName)",
+    {
+      "name": "ConnectedServiceName",
+      "type": "connectedService:AzureRM",
+      "label": "Azure RM Subscription",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Select the Azure Resource Manager subscription for the deployment.",
+      "visibleRule": "ConnectedServiceNameSelector = ConnectedServiceName"
+    },
+    {
+      "name": "ConnectedServiceNameClassic",
+      "type": "connectedService:Azure",
+      "label": "Classic Azure Subscription",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Select the Classic Azure subscription for the deployment.",
+      "visibleRule": "ConnectedServiceNameSelector = ConnectedServiceNameClassic"
+    },
+    {
+      "name": "action",
+      "type": "pickList",
+      "label": "Action",
+      "defaultValue": "Create Or Update Resource Group",
+      "required": true,
+      "helpMarkDown": "Action to be performed on the Azure resources or resource group.",
+      "options": {
+        "Create Or Update Resource Group": "Create Or Update Resource Group",
+        "Select Resource Group": "Select Resource Group",
+        "Start": "Start Virtual Machines",
+        "Stop": "Stop Virtual Machines",
+        "Restart": "Restart Virtual Machines",
+        "Delete": "Delete Virtual Machines",
+        "DeleteRG": "Delete Resource Group"
+      },
+      "visibleRule": "ConnectedServiceNameSelector = ConnectedServiceName"
+    },
+    {
+      "name": "actionClassic",
+      "type": "pickList",
+      "label": "Action",
+      "defaultValue": "Select Resource Group",
+      "required": true,
+      "helpMarkDown": "Action to be performed on the Azure resources or cloud service.",
+      "options": {
+        "Select Resource Group": "Select Cloud Service"
+      },
+      "visibleRule": "ConnectedServiceNameSelector = ConnectedServiceNameClassic"
+    },
+    {
+      "name": "resourceGroupName",
+      "type": "pickList",
+      "label": "Resource Group",
+      "required": true,
+      "helpMarkDown": "Provide the name of the resource group.",
+      "visibleRule": "ConnectedServiceNameSelector = ConnectedServiceName"
+    },
+    {
+      "name": "cloudService",
+      "type": "pickList",
+      "label": "Cloud Service",
+      "required": true,
+      "helpMarkDown": "Provide the name of the cloud service.",
+      "visibleRule": "ConnectedServiceNameSelector = ConnectedServiceNameClassic"
+    },
+    {
+      "name": "location",
+      "type": "pickList",
+      "label": "Location",
+      "defaultValue": "East US",
+      "required": true,
+      "helpMarkDown": "Location for deploying the resource group. If the resource group already exists in the subscription, then this value will be ignored.",
+      "options": {
+        "Australia East": "Australia East",
+        "Australia Southeast": "Australia Southeast",
+        "Brazil South": "Brazil South",
+        "Central US": "Central US",
+        "East Asia": "East Asia",
+        "East US": "East US",
+        "East US 2 ": "East US 2 ",
+        "Japan East": "Japan East",
+        "Japan West": "Japan West",
+        "North Central US": "North Central US",
+        "North Europe": "North Europe",
+        "South Central US": "South Central US",
+        "Southeast Asia": "Southeast Asia",
+        "West Europe": "West Europe",
+        "West US": "West US"
+      },
+      "properties": {
+        "EditableOptions": "True"
+      },
+      "visibleRule": "action = Create Or Update Resource Group"
+    },
+    {
+      "name": "csmFile",
+      "type": "filePath",
+      "label": "Template",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Specify the path to the Azure Resource Manager template. For more information about the templates see http://aka.ms/azuretemplates. To get started immediately use template http://aka.ms/sampletemplate.",
+      "visibleRule": "action = Create Or Update Resource Group"
+    },
+    {
+      "name": "csmParametersFile",
+      "type": "filePath",
+      "label": "Template Parameters",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Specify the path for the parameters file for the Azure Resource Manager Template.",
+      "visibleRule": "action = Create Or Update Resource Group"
+    },
+    {
+      "name": "overrideParameters",
+      "type": "multiLine",
+      "label": "Override Template Parameters",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Specify the template parameters to override like, <br>–storageName fabrikam –adminUsername $(vmusername) -adminPassword (ConvertTo-SecureString -String '$(password)' -AsPlainText -Force) –azureKeyVaultName $(fabrikamFibre).",
+      "visibleRule": "action = Create Or Update Resource Group"
+    },
+    {
+      "name": "enableDeploymentPrerequisitesForCreate",
+      "type": "boolean",
+      "label": "Enable Deployment Prerequisites",
+      "defaultValue": "false",
+      "visibleRule": "action = Create Or Update Resource Group",
+      "required": false,
+      "helpMarkDown": "Enabling this option configures Windows Remote Management (WinRM) listener over HTTPS protocol on port 5986, using a self-signed certificate. This configuration is required for performing deployment operation on Azure machines. If the target Virtual Machines are backed by a Load balancer, ensure Inbound NAT rules are configured for target port (5986). If the target Virtual Machines are associated with a Network security group (NSG), configure Inbound security rules for Destination port (5986)."
+    },
+    {
+      "name": "enableDeploymentPrerequisitesForSelect",
+      "type": "boolean",
+      "label": "Enable Deployment Prerequisites",
+      "defaultValue": "false",
+      "visibleRule": "action = Select Resource Group",
+      "required": false,
+      "helpMarkDown": "Enabling this option configures Windows Remote Management (WinRM) listener over HTTPS protocol on port 5986, using a self-signed certificate. This configuration is required for performing deployment operation on Azure machines. If the target Virtual Machines are backed by a Load balancer, ensure Inbound NAT rules are configured for target port (5986). If the target Virtual Machines are associated with a Network security group (NSG), configure Inbound security rules for Destination port (5986). Applicable only for ARM VMs."
+    },
+    {
+      "name": "outputVariable",
+      "type": "string",
+      "label": "Resource Group",
+      "required": false,
+      "defaultValue": "",
+      "groupName": "output",
+      "helpMarkDown": "Provide a name for the variable for the resource group. The variable can be used as $(variableName) to refer to the resource group in subsequent tasks like in the PowerShell on Target Machines task for deploying applications. <br>Valid only when the selected action is Create, Update or Select, and required when an existing resource group is selected."
+    }
+  ],
+  "dataSourceBindings": [
+    {
+      "target": "cloudService",
+      "endpointId": "$(ConnectedServiceNameClassic)",
+      "dataSourceName": "AzureHostedServiceNames"
+    },
+    {
+      "target": "resourceGroupName",
+      "endpointId": "$(ConnectedServiceName)",
+      "dataSourceName": "AzureVirtualMachinesV2Details",
+      "resultTemplate": "{{#extractResourceGroup id}}"
+    }
+  ],
+  "instanceNameFormat": "Azure Deployment:$(action) action on $(resourceGroupName)",
   "execution": {
     "AzurePowerShell": {
       "target": "$(currentDirectory)\\DeployAzureResourceGroup.ps1",

--- a/Tasks/DeployAzureResourceGroup/task.loc.json
+++ b/Tasks/DeployAzureResourceGroup/task.loc.json
@@ -199,8 +199,8 @@
     {
       "target": "resourceGroupName",
       "endpointId": "$(ConnectedServiceName)",
-      "dataSourceName": "AzureVirtualMachinesV2Details",
-      "resultTemplate": "{{#extractResourceGroup id}}"
+      "dataSourceName": "AzureVirtualMachinesV2Id",
+      "resultTemplate": "{{#extractResource resourceGroups}}"
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/DeployAzureResourceGroup/task.loc.json
+++ b/Tasks/DeployAzureResourceGroup/task.loc.json
@@ -21,7 +21,7 @@
   "demands": [
     "azureps"
   ],
-  "minimumAgentVersion": "1.95.0",
+  "minimumAgentVersion": "1.94.0",
   "groups": [
     {
       "name": "output",
@@ -195,14 +195,12 @@
       "target": "cloudService",
       "endpointId": "$(ConnectedServiceNameClassic)",
       "dataSourceName": "AzureHostedServiceNames"
-    }
-  ],
-  "sourceDefinitions": [
+    },
     {
       "target": "resourceGroupName",
-      "endpoint": "https://management.azure.com/subscriptions/$(authKey.SubscriptionId)/resourcegroups?api-version=2015-01-01",
-      "selector": "jsonpath:$.value[*].name",
-      "authKey": "$(ConnectedServiceName)"
+      "endpointId": "$(ConnectedServiceName)",
+      "dataSourceName": "AzureVirtualMachinesV2Details",
+      "resultTemplate": "{{#extractResourceGroup id}}"
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
Adding DatasourceBindings instead of sourceDefinition in tasks. Demoting agent version, as changes got in last sprint