### PR TITLE
Adding warning when ANT_HOME is not set

### DIFF
--- a/Tasks/ANT/anttask.ts
+++ b/Tasks/ANT/anttask.ts
@@ -23,6 +23,12 @@ if (antHomeUserInputPath) {
     process.env['ANT_HOME'] = antHomeUserInputPath;
 }
 
+// Warn if ANT_HOME is not set either locally or on the task via antHomeUserInputPath
+var antHome = tl.getVariable('ANT_HOME');
+if (!antHome) {
+    tl.warning('The ANT_HOME environment variable is not set.  Please make sure that it exists and is set to the location of the bin folder.  See http://ant.apache.org/manual/install.html.');
+}
+
 // update JAVA_HOME if user selected specific JDK version or set path manually
 var javaHomeSelection = tl.getInput('javaHomeSelection', true);
 var specifiedJavaHome = null;

--- a/Tasks/ANT/task.json
+++ b/Tasks/ANT/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 28
+        "Patch": 29
     },
     "demands" : [
         "ant"

--- a/Tasks/ANT/task.loc.json
+++ b/Tasks/ANT/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 28
+    "Patch": 29
   },
   "demands": [
     "ant"


### PR DESCRIPTION
Improving the user experience if ANT_HOME isn't set.  Using a warning (instead of an error) because there are basic scenarios where ANT_HOME doesn't need to be set (e.g., "HelloWorld.java"-type projects).