### PR TITLE
Missing loc strings. Combine msbuild.exe.

### DIFF
--- a/Tasks/Common/MSBuildHelpers/InvokeFunctions.ps1
+++ b/Tasks/Common/MSBuildHelpers/InvokeFunctions.ps1
@@ -183,7 +183,7 @@ function Invoke-MSBuild {
             $MSBuildPath = Get-MSBuildPath
         } else {
             $MSBuildPath = [System.Environment]::ExpandEnvironmentVariables($MSBuildPath)
-            if (!$MSBuildPath -like '*msbuild.exe') {
+            if ($MSBuildPath -notlike '*msbuild.exe') {
                 $MSBuildPath = [System.IO.Path]::Combine($MSBuildPath, 'msbuild.exe')
             }
         }

--- a/Tasks/MSBuild/Select-MSBuildLocation.ps1
+++ b/Tasks/MSBuild/Select-MSBuildLocation.ps1
@@ -36,7 +36,7 @@ function Select-MSBuildLocation {
 
                 # Warn if not found.
                 if (!$Location) {
-                    Write-Warning (Get-VstsLocString -Key 'UnableToFindMSBuildVersion0Architecture1LookingForLatestVersion.' -ArgumentList $Version, $Architecture)
+                    Write-Warning (Get-VstsLocString -Key 'UnableToFindMSBuildVersion0Architecture1LookingForLatestVersion' -ArgumentList $Version, $Architecture)
                 }
             }
 

--- a/Tasks/MSBuild/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/MSBuild/Strings/resources.resjson/en-US/resources.resjson
@@ -21,5 +21,7 @@
   "loc.input.label.msbuildArchitecture": "MSBuild Architecture",
   "loc.input.help.msbuildArchitecture": "Optionally supply the architecture (x86, x64) of MSBuild to run.",
   "loc.input.label.msbuildLocation": "Path to MSBuild",
-  "loc.input.help.msbuildLocation": "Optionally supply the path to MSBuild."
+  "loc.input.help.msbuildLocation": "Optionally supply the path to MSBuild.",
+  "loc.messages.UnableToFindMSBuildVersion0Architecture1LookingForLatestVersion": "Unable to find MSBuild: Version = {0}, Architecture = {1}. Looking for the latest version.",
+  "loc.messages.MSBuildNotFoundVersion0Architecture1TryDifferent": "MSBuild not found: Version = {0}, Architecture = {1}. Try a different version/architecture combination, specify a location, or install the appropriate MSBuild version/architecture."
 }

--- a/Tasks/MSBuild/task.json
+++ b/Tasks/MSBuild/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 21
+        "Patch": 22
     },
     "demands" : [
         "msbuild"
@@ -143,5 +143,9 @@
             "argumentFormat": "",
             "workingDirectory": "$(currentDirectory)"
         }
+    },
+    "messages": {
+        "UnableToFindMSBuildVersion0Architecture1LookingForLatestVersion": "Unable to find MSBuild: Version = {0}, Architecture = {1}. Looking for the latest version.",
+        "MSBuildNotFoundVersion0Architecture1TryDifferent": "MSBuild not found: Version = {0}, Architecture = {1}. Try a different version/architecture combination, specify a location, or install the appropriate MSBuild version/architecture."
     }
 }

--- a/Tasks/MSBuild/task.json
+++ b/Tasks/MSBuild/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 22
+        "Patch": 23
     },
     "demands" : [
         "msbuild"

--- a/Tasks/MSBuild/task.loc.json
+++ b/Tasks/MSBuild/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 22
+    "Patch": 23
   },
   "demands": [
     "msbuild"

--- a/Tasks/MSBuild/task.loc.json
+++ b/Tasks/MSBuild/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 21
+    "Patch": 22
   },
   "demands": [
     "msbuild"
@@ -143,5 +143,9 @@
       "argumentFormat": "",
       "workingDirectory": "$(currentDirectory)"
     }
+  },
+  "messages": {
+    "UnableToFindMSBuildVersion0Architecture1LookingForLatestVersion": "ms-resource:loc.messages.UnableToFindMSBuildVersion0Architecture1LookingForLatestVersion",
+    "MSBuildNotFoundVersion0Architecture1TryDifferent": "ms-resource:loc.messages.MSBuildNotFoundVersion0Architecture1TryDifferent"
   }
 }

--- a/Tasks/VSBuild/task.json
+++ b/Tasks/VSBuild/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 22
+        "Patch": 23
     },
     "demands": [
         "msbuild",

--- a/Tasks/VSBuild/task.loc.json
+++ b/Tasks/VSBuild/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 22
+    "Patch": 23
   },
   "demands": [
     "msbuild",

--- a/Tests/L0/Common-MSBuildHelpers/Invoke-MSBuild.CombinesMsbuildexe.ps1
+++ b/Tests/L0/Common-MSBuildHelpers/Invoke-MSBuild.CombinesMsbuildexe.ps1
@@ -1,0 +1,27 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\lib\Initialize-Test.ps1
+$module = Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..\..\..\Tasks\MSBuild\ps_modules\MSBuildHelpers -PassThru
+$env:msBuildDir = 'C:\Some msbuild dir'
+$msBuildPath = "%msBuildDir%"
+$expectedMSBuildPath = "C:\Some msbuild dir\msbuild.exe"
+Register-Mock Assert-VstsPath
+Register-Mock Get-VstsTaskVariable { "C:\Some agent home directory" } -- -Name Agent.HomeDirectory -Require
+Register-Mock Invoke-VstsTool { 'Some output 1', 'Some output 2' }
+$LASTEXITCODE = 0
+Register-Mock Write-VstsSetResult
+
+# Act.
+$actual = & $module Invoke-MSBuild -ProjectFile 'Some project file' -NoTimelineLogger -MSBuildPath $msBuildPath
+
+# Assert.
+Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedMSBuildPath -PathType Leaf
+Assert-WasCalled Assert-VstsPath -- -LiteralPath "C:\Some agent home directory\Agent\Worker\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll" -PathType Leaf
+Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"Some project file`" /nologo /m /nr:false /dl:CentralLogger,`"C:\Some agent home directory\Agent\Worker\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll`"*ForwardingLogger,`"C:\Some agent home directory\Agent\Worker\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll`"" -RequireExitCodeZero
+Assert-WasCalled Write-VstsSetResult -Times 0
+Assert-AreEqual -Expected @(
+    'Some output 1'
+    'Some output 2'
+) -Actual $actual

--- a/Tests/L0/Common-MSBuildHelpers/_suite.ts
+++ b/Tests/L0/Common-MSBuildHelpers/_suite.ts
@@ -58,5 +58,8 @@ describe('Common-MSBuildHelpers Suite', function () {
         it('(Invoke-BuildTools) skips restore if specified', (done) => {
             psm.runPS(path.join(__dirname, 'Invoke-BuildTools.SkipsRestoreIfSpecified.ps1'), done);
         })
+        it('(Invoke-MSBuild) combines msbuildexe', (done) => {
+            psm.runPS(path.join(__dirname, 'Invoke-MSBuild.CombinesMsbuildexe.ps1'), done);
+        })
     }
 });

--- a/Tests/L0/Loc/_suite.ts
+++ b/Tests/L0/Loc/_suite.ts
@@ -22,33 +22,37 @@ describe('Loc String Suite', function() {
 		this.timeout(1000);
 		
 		var tasksRootFolder =  path.resolve(__dirname, '../../../Tasks');
-		
-		var taskFolders: string[] = [];
+		var jsons: string[] = [];
 		fs.readdirSync(tasksRootFolder).forEach(folderName=> {
 			if(fs.statSync(path.join(tasksRootFolder, folderName)).isDirectory()) { 
-				taskFolders.push(path.join(tasksRootFolder, folderName));	
+				jsons.push(path.join(tasksRootFolder, folderName, "task.json"));
 			}
 		})
+        // The Common folder does not get copied under _build so scan the source folder instead.
+        var commonFolder = path.resolve(__dirname, "../../../../Tasks/Common");
+        fs.readdirSync(commonFolder).forEach(folderName => {
+            var moduleFolder = path.join(commonFolder, folderName);
+            var moduleJson = path.join(moduleFolder, "module.json");
+            if (fs.statSync(moduleFolder).isDirectory() && fs.existsSync(moduleJson)) {
+                jsons.push(moduleJson);
+            }
+        })
 
-		for(var i = 0; i < taskFolders.length; i++) {
-			var taskFolder = taskFolders[i];
-
-			var taskjson = path.join(taskFolder, 'task.json');
-			var task = require(taskjson);
-
-			if(task.hasOwnProperty('messages')) {
-				for(var key in task.messages) {
-					var taskName = path.relative(tasksRootFolder, taskjson);
-					
-					assert(key.search(/\W+/gi) < 0, ('(' + taskName +')' + 'messages key: \'' + key +'\' contain non-word characters, only allows [a-zA-Z0-9_].'));
-					if(typeof(task.messages[key]) === 'object') {
-						assert(task.messages[key].loc, ('(' + taskName +')' + 'messages key: \'' + key +'\' should have a loc string.'));
-						assert(task.messages[key].loc.toString().length >= 0, ('(' + taskName +')' + 'messages key: \'' + key +'\' should have a loc string.'));
-						assert(task.messages[key].fallback, ('(' + taskName +')' + 'messages key: \'' + key +'\' should have a fallback string.'));
-						assert(task.messages[key].fallback.toString().length > 0, ('(' + taskName +')' + 'messages key: \'' + key +'\' should have a fallback string.'));
+		for(var i = 0; i < jsons.length; i++) {
+			var json = jsons[i];
+			var obj = require(json);
+			if(obj.hasOwnProperty('messages')) {
+				for(var key in obj.messages) {
+					var jsonName = path.relative(tasksRootFolder, json);
+					assert(key.search(/\W+/gi) < 0, ('(' + jsonName +')' + 'messages key: \'' + key +'\' contain non-word characters, only allows [a-zA-Z0-9_].'));
+					if(typeof(obj.messages[key]) === 'object') {
+						assert(obj.messages[key].loc, ('(' + jsonName +')' + 'messages key: \'' + key +'\' should have a loc string.'));
+						assert(obj.messages[key].loc.toString().length >= 0, ('(' + jsonName +')' + 'messages key: \'' + key +'\' should have a loc string.'));
+						assert(obj.messages[key].fallback, ('(' + jsonName +')' + 'messages key: \'' + key +'\' should have a fallback string.'));
+						assert(obj.messages[key].fallback.toString().length > 0, ('(' + jsonName +')' + 'messages key: \'' + key +'\' should have a fallback string.'));
 					}
-					else if(typeof(task.messages[key]) === 'string') {
-						assert(task.messages[key].toString().length > 0, ('(' + taskName +')' + 'messages key: \'' + key +'\' should have a loc string.'));
+					else if(typeof(obj.messages[key]) === 'string') {
+						assert(obj.messages[key].toString().length > 0, ('(' + jsonName +')' + 'messages key: \'' + key +'\' should have a loc string.'));
 					} 
         		}
 			}
@@ -138,4 +142,75 @@ describe('Loc String Suite', function() {
 		
 		done();
 	})
+
+    it('Find missing string in .ps1/.psm1', (done) => {
+        this.timeout(10000);
+
+        // Push all task folders onto the stack.
+        var folders: string[] = [];
+        var tasksRootFolder =  path.resolve(__dirname, '../../../Tasks');
+        fs.readdirSync(tasksRootFolder).forEach(folderName => {
+            var folder = path.join(tasksRootFolder, folderName);
+            if (folderName != 'Common' && fs.statSync(folder).isDirectory()) {
+                folders.push(folder);
+            }
+        })
+
+        // Push each Common module folder onto the stack. The Common folder does not
+        // get copied under _build so scan the source copy instead.
+        var commonFolder = path.resolve(__dirname, "../../../../Tasks/Common");
+        fs.readdirSync(commonFolder).forEach(folderName=> {
+            var folder = path.join(commonFolder, folderName);
+            if (fs.statSync(folder).isDirectory()) {
+                folders.push(folder);
+            }
+        })
+
+        folders.forEach(folder => {
+            // Load the task.json or module.json if one exists.
+            var jsonFile = path.join(folder, 'task.json');
+            var obj = { "messages": { } }
+            if (fs.existsSync(jsonFile) || fs.existsSync(jsonFile = path.join(folder, "module.json"))) {
+                obj = require(jsonFile);
+            } else {
+                jsonFile = ''
+            }
+
+            // Recursively find all PS files.
+            var psFiles: string[] = [];
+            var folderStack: string[] = [ folder ];
+            while (folderStack.length > 0) {
+                folder = folderStack.pop();
+                if (path.basename(folder).toLowerCase() == "ps_modules") { continue } // Skip nested ps_modules folder.
+                fs.readdirSync(folder).forEach(itemName => {
+                    var itemPath = path.join(folder, itemName);
+                    if (fs.statSync(itemPath).isDirectory()) {
+                        folderStack.push(itemPath);
+                    } else if (itemPath.toLowerCase().search(/\.ps1$/) > 0
+                        || itemPath.toLowerCase().search(/\.psm1$/) > 0) {
+                        psFiles.push(itemPath);
+                    }
+                })
+            }
+
+            psFiles.forEach(psFile => {
+                var ps = fs.readFileSync(psFile).toString().replace(/\r\n/g,'\n').replace(/\r/g,'\n');
+                var lines: string[] = ps.split('\n');
+                lines.forEach(line => {
+                    if (line.search(/Get-VstsLocString/i) > 0) {
+                        var result = /Get-VstsLocString +-Key +('[^']+'|"[^"]+"|[^ )]+)/i.exec(line);
+                        if (!result) {
+                            assert(false, 'Bad format string in file ' + psFile + ' on line: ' + line);
+                        }
+
+                        var key = result[1].replace(/['"]/g, "");
+                        assert(
+                            obj.hasOwnProperty('messages') && obj.messages.hasOwnProperty(key),
+                            "Loc resource key not found in task.json/module.json. Resource key: '" + key + "', PS file: '" + psFile + "', JSON file: '" + jsonFile + "'.");
+                    }
+                });
+            })
+        })
+        done();
+    })
 });

--- a/Tests/lib/psRunner.ts
+++ b/Tests/lib/psRunner.ts
@@ -60,20 +60,20 @@ export class PSRunner extends events.EventEmitter {
 							env: process.env
 						},
 			(err, stdout, stderr) => {
+				if (stdout) {
+					debug(stdout);
+				}
+
+				if (stderr) {
+					debug('stderr:');
+					debug(stderr);
+				}
+
 				if (err !== null) {
 					defer.reject(err);
 					return;
 				}
 
-				if (stdout) {
-					debug(stdout);
-				}
-				
-				if (stderr) {
-					debug('stderr:');
-					debug(stderr);
-				}
-				
 				defer.resolve(null);
 			});
 		


### PR DESCRIPTION
Is the fix already in master?  If not, link the bug tracking that work.
Yes

What testing was done?
Added unit tests. Tested the tasks E2E - xcopied the fix over my task script on disk. Ran through E2E scenarios to produce the warning messages and execute the logic that combines msbuild.exe with the path. Also excersized logic where the path doesn't need to be combined to verify not introducing a regression there.

Does this fix change the AT/DT contract?
No

Does this fix include any database servicing changes?
No

Were tests added to cover this to make sure it doesn't regress?  If not, link a bug or user story tracking that work.
Yes