### PR TITLE
Fix #1190 - Pass the resolved path to the .cscfg file into Get-DiagnosticsExtensions

### DIFF
--- a/Tasks/AzureCloudPowerShellDeployment/Publish-AzureCloudDeployment.ps1
+++ b/Tasks/AzureCloudPowerShellDeployment/Publish-AzureCloudDeployment.ps1
@@ -233,7 +233,7 @@ if (!$azureService)
     $azureService = Invoke-Expression -Command $azureService
 }
 
-$diagnosticExtensions = Get-DiagnosticsExtensions $StorageAccount $CsCfg
+$diagnosticExtensions = Get-DiagnosticsExtensions $StorageAccount $serviceConfigFile
 
 $label = $DeploymentLabel
 


### PR DESCRIPTION
Changed the path passed into `Get-DiagnosticsExtensions` from the raw path passed in to the resolved path to the .cscfg file. This resolves the issue where the raw path may be a minimatch pattern.