### PR TITLE
Use password set in original Nuget.config

### DIFF
--- a/Tasks/NuGetInstaller/VsoNuGetHelper.ps1
+++ b/Tasks/NuGetInstaller/VsoNuGetHelper.ps1
@@ -153,7 +153,7 @@ function SetCredentialsNuGetConfigAndSaveTemp
                 if([string]::Equals(([System.Xml.XmlNode]$section).Attributes["key"].Value, "password", "InvariantCultureIgnoreCase"))
                 {
                     Write-Verbose "Setting new credential for $encodedSource"
-                    $encryptedPassword = EncryptNuGetPassword $accessToken
+                    $encryptedPassword = EncryptNuGetPassword ([System.Xml.XmlNode]$section).Attributes["value"].Value
                     ([System.Xml.XmlNode]$section).Attributes["value"].Value = $encryptedPassword
                 }
             }


### PR DESCRIPTION
I think if this is using the username from the solution's original nuget.config that it should also use the password from there, rather than the VssSessionToken.