### PR TITLE
Add NugetPackager support for 3 part build numbers

### DIFF
--- a/Tasks/NugetPackager/NuGetPackager.ps1
+++ b/Tasks/NugetPackager/NuGetPackager.ps1
@@ -26,7 +26,7 @@ if ($b_versionByBuild)
     
     # Regular expression pattern to find the version in the build number 
     # and then apply it to the assemblies
-    $VersionRegex = "\d+\.\d+\.\d+\.\d+"
+    $VersionRegex = "\d+\.\d+\.\d+(?:\.\d+)?"
     
     # If this script is not running on a build server, remind user to 
     # set environment variables so that this script can be debugged

--- a/Tasks/NugetPackager/task.json
+++ b/Tasks/NugetPackager/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 58
+        "Patch": 59
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [


### PR DESCRIPTION
When using the Nuget Packager task if you select "Use Build number to version package" and your build number is a 3 part number (1.2.3) the task fails because it expects a 4 part number (1.2.3.4).  It seems like this should be supported based on the nuget version documentation: https://docs.nuget.org/create/versioning