### PR TITLE
Remove cocoapods demand

### DIFF
--- a/Tasks/CocoaPods/cocoapods.ts
+++ b/Tasks/CocoaPods/cocoapods.ts
@@ -5,17 +5,23 @@ import tl = require('vsts-task-lib/task');
 tl.cd(tl.getPathInput('cwd', true, true));
 
 tl.debug('Setting locale to UTF8 - required by CocoaPods');
-process.env['LC_ALL']='en_US.UTF-8';
+process.env['LC_ALL'] = 'en_US.UTF-8';
 
-var tool = tl.which('pod', true);
-var pod = tl.createToolRunner(tool);
-pod.arg('install');
+var tool = tl.which('pod');
+if (tool) {
+    var pod = tl.createToolRunner(tool);
+    pod.arg('install');
 
-pod.exec()
-.then(function(code) {
-	tl.exit(code);
-})
-.fail(function(err) {
-	tl.debug('taskRunner fail');
-	tl.exit(1);
-})
+    pod.exec()
+        .then(function(code) {
+            tl.exit(code);
+        })
+        .fail(function(err) {
+            tl.debug('taskRunner fail');
+            tl.exit(1);
+        });
+} else {
+    tl.error('command pod was not found. Please install Cocoapods on the build machine (https://cocoapods.org)');
+    tl.debug('taskRunner fail: pod not found');
+    tl.exit(1);
+}

--- a/Tasks/CocoaPods/task.json
+++ b/Tasks/CocoaPods/task.json
@@ -12,11 +12,8 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 7
+        "Patch": 8
     },
-    "demands": [
-        "cocoapods"
-    ],
     "instanceNameFormat": "pod install",
     "inputs": [
         {

--- a/Tasks/CocoaPods/task.loc.json
+++ b/Tasks/CocoaPods/task.loc.json
@@ -12,11 +12,8 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 7
+    "Patch": 8
   },
-  "demands": [
-    "cocoapods"
-  ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [
     {


### PR DESCRIPTION
Removes direct cocoapods demand from cocoapods task.
Adds a message indicating that cocoapods should be installed on build machine if the pod command is not found.

Addresses issue https://github.com/Microsoft/vso-agent-tasks/issues/813

@bryanmacfarlane @Chuxel 