### PR TITLE
Users/nigurr/fix vs test dll input

### DIFF
--- a/Tasks/VsTest/README.md
+++ b/Tasks/VsTest/README.md
@@ -12,7 +12,7 @@ VSTest task can be used to run tests on Build agent machines. Using the appropri
 
 For example, `**\commontests\*test*.dll; **\frontendtests\*test*.dll;-:**\obj\**` or `$(Build.SourcesDirectory)\Tests\*tests*.dll;-:$(Build.SourcesDirectory)\Tests\Integrationtests.dll`
 
-Include patterns start with ‘+:’, and exclude patterns with ‘-:’ (Default is include). For Javascript tests, this will point to .js files containing the tests
+Include patterns start with ‘+:’, and exclude patterns with ‘-:’ (Default is include). For Javascript tests, this will point to .js files containing the tests. We don't support the folders/files which are having ";" in their names.
 
 - **Test Filter Criteria:**	Filters tests from within the test assembly files. For example, “Priority=1 | Name=MyTestMethod”. This option works the same way as the console option /TestCaseFilter of vstest.console.exe
 

--- a/Tasks/VsTest/README.md
+++ b/Tasks/VsTest/README.md
@@ -12,7 +12,7 @@ VSTest task can be used to run tests on Build agent machines. Using the appropri
 
 For example, `**\commontests\*test*.dll; **\frontendtests\*test*.dll;-:**\obj\**` or `$(Build.SourcesDirectory)\Tests\*tests*.dll;-:$(Build.SourcesDirectory)\Tests\Integrationtests.dll`
 
-Include patterns start with ‘+:’, and exclude patterns with ‘-:’ (Default is include). For Javascript tests, this will point to .js files containing the tests. We don't support the folders/files which are having ";" in their names.
+Include patterns start with ‘+:’, and exclude patterns with ‘-:’ (Default is include). For Javascript tests, this will point to .js files containing the tests. Folders/Files which are having ";" in their names should be given as ";;" in input.
 
 - **Test Filter Criteria:**	Filters tests from within the test assembly files. For example, “Priority=1 | Name=MyTestMethod”. This option works the same way as the console option /TestCaseFilter of vstest.console.exe
 

--- a/Tasks/VsTest/VSTest.ps1
+++ b/Tasks/VsTest/VSTest.ps1
@@ -69,7 +69,11 @@ if ($testAssembly.Contains("*") -Or $testAssembly.Contains("?"))
 else
 {
     Write-Verbose "No Pattern found in solution parameter."
-    $testAssemblyFiles += ,$testAssembly.Split(";")
+    $testAssembly = $testAssembly.Replace(';;', "`0") # Barrowed from Legacy File Handler
+    foreach ($assembly in $testAssembly.Split(";"))
+    {
+        $testAssemblyFiles += ,($assembly.Replace("`0",";"))
+    }
 }
 
 $codeCoverage = Convert-String $codeCoverageEnabled Boolean

--- a/Tasks/VsTest/VSTest.ps1
+++ b/Tasks/VsTest/VSTest.ps1
@@ -68,7 +68,7 @@ if ($testAssembly.Contains("*") -Or $testAssembly.Contains("?"))
 else
 {
     Write-Verbose "No Pattern found in solution parameter."
-    $testAssembly = $testAssembly.Split(";")
+    $testAssembly = $testAssembly.Split(";") 
     $testAssemblyFiles = ,$testAssembly
 }
 

--- a/Tasks/VsTest/VSTest.ps1
+++ b/Tasks/VsTest/VSTest.ps1
@@ -57,6 +57,7 @@ if(!$sourcesDirectory)
     throw (Get-LocalizedString -Key "No source directory found.")
 }
 
+$testAssemblyFiles = @()
 # check for solution pattern
 if ($testAssembly.Contains("*") -Or $testAssembly.Contains("?"))
 {
@@ -68,8 +69,7 @@ if ($testAssembly.Contains("*") -Or $testAssembly.Contains("?"))
 else
 {
     Write-Verbose "No Pattern found in solution parameter."
-    $testAssembly = $testAssembly.Split(";") 
-    $testAssemblyFiles = ,$testAssembly
+    $testAssemblyFiles += ,$testAssembly.Split(";")
 }
 
 $codeCoverage = Convert-String $codeCoverageEnabled Boolean

--- a/Tasks/VsTest/VSTest.ps1
+++ b/Tasks/VsTest/VSTest.ps1
@@ -68,6 +68,7 @@ if ($testAssembly.Contains("*") -Or $testAssembly.Contains("?"))
 else
 {
     Write-Verbose "No Pattern found in solution parameter."
+    $testAssembly = $testAssembly.Split(";")
     $testAssemblyFiles = ,$testAssembly
 }
 

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 30
+    "Patch": 31
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 30
+    "Patch": 31
   },
   "demands": [
     "vstest"

--- a/Tests/L0/VsTest/ValidateTestAssembliesAreNotSplit.ps1
+++ b/Tests/L0/VsTest/ValidateTestAssembliesAreNotSplit.ps1
@@ -6,12 +6,12 @@ param()
 Register-Mock Get-TaskVariable { "c:\testSource" }
 Register-Mock Convert-String { $true }
 Register-Mock Find-Files { $true }
-Register-Mock Invoke-VSTest { $true } -TestAssemblies @("c:\test1.dll","c:\test2.dll") -VSTestVersion "vsTestVersion" -TestFiltercriteria "testFiltercriteria" -RunSettingsFile "runSettingsFile" -PathtoCustomTestAdapters "pathtoCustomTestAdapters" -CodeCoverageEnabled $true -OverrideTestrunParameters "overrideTestrunParameters" -OtherConsoleOptions "otherConsoleOptions" -WorkingFolder "c:\testSource" -TestResultsFolder "c:\testSource\TestResults" -SourcesDirectory "c:\testSource"
+Register-Mock Invoke-VSTest { $true } -TestAssemblies @("c:\test1.dll,c:\test2.dll") -VSTestVersion "vsTestVersion" -TestFiltercriteria "testFiltercriteria" -RunSettingsFile "runSettingsFile" -PathtoCustomTestAdapters "pathtoCustomTestAdapters" -CodeCoverageEnabled $true -OverrideTestrunParameters "overrideTestrunParameters" -OtherConsoleOptions "otherConsoleOptions" -WorkingFolder "c:\testSource" -TestResultsFolder "c:\testSource\TestResults" -SourcesDirectory "c:\testSource"
 Register-Mock Publish-TestResults { $true }
 
 $splat = @{
     'vsTestVersion' = 'vsTestVersion'
-    'testAssembly' = 'c:\test1.dll;c:\test2.dll' 
+    'testAssembly' = 'c:\test1.dll,c:\test2.dll' 
     'testFiltercriteria' = 'testFiltercriteria' 
     'runSettingsFile' = 'runSettingsFile' 
     'codeCoverageEnabled' = 'true'

--- a/Tests/L0/VsTest/ValidateTestAssembliesAreSplit.ps1
+++ b/Tests/L0/VsTest/ValidateTestAssembliesAreSplit.ps1
@@ -6,12 +6,12 @@ param()
 Register-Mock Get-TaskVariable { "c:\testSource" }
 Register-Mock Convert-String { $true }
 Register-Mock Find-Files { $true }
-Register-Mock Invoke-VSTest { $true } -TestAssemblies @("c:\test1.dll","c:\test2.dll") -VSTestVersion "vsTestVersion" -TestFiltercriteria "testFiltercriteria" -RunSettingsFile "runSettingsFile" -PathtoCustomTestAdapters "pathtoCustomTestAdapters" -CodeCoverageEnabled $true -OverrideTestrunParameters "overrideTestrunParameters" -OtherConsoleOptions "otherConsoleOptions" -WorkingFolder "c:\testSource" -TestResultsFolder "c:\testSource\TestResults" -SourcesDirectory "c:\testSource"
+Register-Mock Invoke-VSTest { $true } -- -TestAssemblies @("c:\test1.dll","c:\test2.dll") -VSTestVersion "vsTestVersion" -TestFiltercriteria "testFiltercriteria" -RunSettingsFile "runSettingsFile" -PathtoCustomTestAdapters "pathtoCustomTestAdapters" -CodeCoverageEnabled $true -OverrideTestrunParameters "overrideTestrunParameters" -OtherConsoleOptions "otherConsoleOptions" -WorkingFolder "c:\testSource" -TestResultsFolder "c:\testSource\TestResults" -SourcesDirectory "c:\testSource"
 Register-Mock Publish-TestResults { $true }
 
 $splat = @{
     'vsTestVersion' = 'vsTestVersion'
-    'testAssembly' = 'c:\test1.dll;c:\test2.dll' 
+    'testAssembly' = 'c:\test1.dll;c:\test2;;.dll;c:\test3.dll' 
     'testFiltercriteria' = 'testFiltercriteria' 
     'runSettingsFile' = 'runSettingsFile' 
     'codeCoverageEnabled' = 'true'
@@ -27,3 +27,4 @@ $splat = @{
 & $PSScriptRoot\..\..\..\Tasks\VsTest\VsTest.ps1 @splat
 
 Assert-WasCalled Invoke-VSTest -Times 1
+Assert-WasCalled Publish-TestResults  -Times 1

--- a/Tests/L0/VsTest/ValidateTestAssembliesAreSplit.ps1
+++ b/Tests/L0/VsTest/ValidateTestAssembliesAreSplit.ps1
@@ -6,7 +6,7 @@ param()
 Register-Mock Get-TaskVariable { "c:\testSource" }
 Register-Mock Convert-String { $true }
 Register-Mock Find-Files { $true }
-Register-Mock Invoke-VSTest { $true } -- -TestAssemblies @("c:\test1.dll","c:\test2.dll") -VSTestVersion "vsTestVersion" -TestFiltercriteria "testFiltercriteria" -RunSettingsFile "runSettingsFile" -PathtoCustomTestAdapters "pathtoCustomTestAdapters" -CodeCoverageEnabled $true -OverrideTestrunParameters "overrideTestrunParameters" -OtherConsoleOptions "otherConsoleOptions" -WorkingFolder "c:\testSource" -TestResultsFolder "c:\testSource\TestResults" -SourcesDirectory "c:\testSource"
+Register-Mock Invoke-VSTest { $true } -- -TestAssemblies @("c:\test1.dll","c:\test2;.dll","c:\test3.dll") -VSTestVersion "vsTestVersion" -TestFiltercriteria "testFiltercriteria" -RunSettingsFile "runSettingsFile" -PathtoCustomTestAdapters "pathtoCustomTestAdapters" -CodeCoverageEnabled $true -OverrideTestrunParameters "overrideTestrunParameters" -OtherConsoleOptions "otherConsoleOptions" -WorkingFolder "c:\testSource" -TestResultsFolder "c:\testSource\TestResults" -SourcesDirectory "c:\testSource"
 Register-Mock Publish-TestResults { $true }
 
 $splat = @{

--- a/Tests/L0/VsTest/ValidateTestAssembliesAreSplit.ps1
+++ b/Tests/L0/VsTest/ValidateTestAssembliesAreSplit.ps1
@@ -5,10 +5,9 @@ param()
 . $PSScriptRoot\..\..\lib\Initialize-Test.ps1
 Register-Mock Get-TaskVariable { "c:\testSource" }
 Register-Mock Convert-String { "true" }
-Register-Mock Find-Files {"true"}
-Register-Mock Invoke-VSTest {$true} -TestAssemblies @("c:\test1.dll","c:\test2.dll") -VSTestVersion $vsTestVersion -TestFiltercriteria "testFiltercriteria" -RunSettingsFile "runSettingsFile" -PathtoCustomTestAdapters "pathtoCustomTestAdapters" -CodeCoverageEnabled $true -OverrideTestrunParameters "overrideTestrunParameters" -OtherConsoleOptions "otherConsoleOptions" -WorkingFolder "c:\testSource" -TestResultsFolder "c:\testSource\TestResults" -SourcesDirectory "c:\testSource"
-Register-Mock Publish-TestResults {$true}
-
+Register-Mock Find-Files { "true" }
+Register-Mock Invoke-VSTest { $true } -TestAssemblies @("c:\test1.dll","c:\test2.dll") -VSTestVersion $vsTestVersion -TestFiltercriteria "testFiltercriteria" -RunSettingsFile "runSettingsFile" -PathtoCustomTestAdapters "pathtoCustomTestAdapters" -CodeCoverageEnabled $true -OverrideTestrunParameters "overrideTestrunParameters" -OtherConsoleOptions "otherConsoleOptions" -WorkingFolder "c:\testSource" -TestResultsFolder "c:\testSource\TestResults" -SourcesDirectory "c:\testSource"
+Register-Mock Publish-TestResults { $true }
 
 $splat = @{
     'vsTestVersion' = 'vsTestVersion'

--- a/Tests/L0/VsTest/ValidateTestAssembliesAreSplit.ps1
+++ b/Tests/L0/VsTest/ValidateTestAssembliesAreSplit.ps1
@@ -1,0 +1,30 @@
+[cmdletbinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\lib\Initialize-Test.ps1
+Register-Mock Get-TaskVariable { "c:\testSource" }
+Register-Mock Convert-String { "true" }
+Register-Mock Find-Files {"true"}
+Register-Mock Invoke-VSTest {$true} -TestAssemblies @("c:\test1.dll","c:\test2.dll") -VSTestVersion $vsTestVersion -TestFiltercriteria "testFiltercriteria" -RunSettingsFile "runSettingsFile" -PathtoCustomTestAdapters "pathtoCustomTestAdapters" -CodeCoverageEnabled $true -OverrideTestrunParameters "overrideTestrunParameters" -OtherConsoleOptions "otherConsoleOptions" -WorkingFolder "c:\testSource" -TestResultsFolder "c:\testSource\TestResults" -SourcesDirectory "c:\testSource"
+Register-Mock Publish-TestResults {$true}
+
+
+$splat = @{
+    'vsTestVersion' = 'vsTestVersion'
+    'testAssembly' = 'c:\test1.dll;c:\test2.dll' 
+    'testFiltercriteria' = 'testFiltercriteria' 
+    'runSettingsFile' = 'runSettingsFile' 
+    'codeCoverageEnabled' = 'true'
+    'pathtoCustomTestAdapters' = 'pathtoCustomTestAdapters'
+    'overrideTestrunParameters' = 'overrideTestrunParameters'
+    'otherConsoleOptions' = 'otherConsoleOptions'
+    'testRunTitle' = 'testRunTitle'
+    'platform' = 'platform'
+    'configuration' = 'configuration'
+    'publishRunAttachments' = 'publishRunAttachments'
+    'runInParallel' = 'runInParallel'
+}   
+& $PSScriptRoot\..\..\..\Tasks\VsTest\VsTest.ps1 @splat
+
+Assert-WasCalled Invoke-VSTest -Times 1

--- a/Tests/L0/VsTest/_suite.ts
+++ b/Tests/L0/VsTest/_suite.ts
@@ -67,5 +67,8 @@ describe('VsTest Suite', function () {
         it('ValidateTestAssembliesAreSplit) tests if the input test assembiles are properly passed to cmdlet', (done) => {
             psm.runPS(path.join(__dirname, 'ValidateTestAssembliesAreSplit.ps1'), done);
         })
+         it('ValidateTestAssembliesAreSplit) tests if the input test assembiles are properly passed to cmdlet', (done) => {
+            psm.runPS(path.join(__dirname, 'ValidateTestAssembliesAreNotSplit.ps1'), done);
+        })
     }
 });

--- a/Tests/L0/VsTest/_suite.ts
+++ b/Tests/L0/VsTest/_suite.ts
@@ -64,5 +64,8 @@ describe('VsTest Suite', function () {
         it('(RunSettingsForParallel.ReturnsNewFileIfParallelIsTrueAndFileNameIsANonRunsettingsFile) returns new file if parallel flag is true and runsettings input is not a runsettings file', (done) => {
             psm.runPS(path.join(__dirname, 'RunSettingsForParallel.ReturnsNewFileIfParallelIsTrueAndFileNameIsANonRunsettingsFile.ps1'), done);
         })
+        it('ValidateTestAssembliesAreSplit) tests if the input test assembiles are properly passed to cmdlet', (done) => {
+            psm.runPS(path.join(__dirname, 'ValidateTestAssembliesAreSplit.ps1'), done);
+        })
     }
 });


### PR DESCRIPTION
if full paths of 2 DLLs separated by semicolon are passed through Test Assembly field - the task fails.
