### PR TITLE
Convert the server name to lowercase automatically

### DIFF
--- a/Tasks/SqlAzureDacpacDeployment/DeploySqlAzure.ps1
+++ b/Tasks/SqlAzureDacpacDeployment/DeploySqlAzure.ps1
@@ -75,6 +75,7 @@ if( [string]::IsNullOrWhitespace($PublishProfile) -eq $false -and $PublishProfil
 
 $ErrorActionPreference = 'Stop'
 
+$ServerName = $ServerName.ToLower()
 $serverFriendlyName = $ServerName.split(".")[0]
 Write-Verbose "Server friendly name is $serverFriendlyName" -Verbose
 

--- a/Tasks/SqlAzureDacpacDeployment/task.json
+++ b/Tasks/SqlAzureDacpacDeployment/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 12
+        "Patch": 13
     },
     "demands": [
         "azureps",

--- a/Tasks/SqlAzureDacpacDeployment/task.loc.json
+++ b/Tasks/SqlAzureDacpacDeployment/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 12
+    "Patch": 13
   },
   "demands": [
     "azureps",


### PR DESCRIPTION
SQL Azure only allows lowercase server names.  Today, this task will fail if there are any non-lowercase letters in the server name.  A common scenario is to deploy a SQL Azure server using an ARM Template, and name the server the same as the Resource Group, but doing a ToLower() inside the ARM template. If you are trying to create a TFS build that deploys the ARM Template then deploys a DACPAC into the new SQL Server, you likely only have the Resource Group Name as a build variable, and no convenient way to convert it to lowercase from within the build.  If this task would automatically do a ToLower on it as proposed it would solve this problem.