### PR TITLE
Pin tsc to working version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "semver": "^4.3.3",
     "shelljs": "^0.3.0",
     "through2": "^0.6.3",
+    "typescript": "1.8.0",
     "validator": "^3.33.0",
     "vsts-task-lib": "^0.5.6"
   },


### PR DESCRIPTION
1.8.2 is latest. Pinning to 1.8.0.

Fyi - task lib repo is currently pinned to 1.8.0-dev.20160104