### PR TITLE
This is workaround to mitigate DTL issue with ARG, where we can't use…

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/DeployTestAgent.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/DeployTestAgent.ps1
@@ -86,7 +86,7 @@ $taskContextMemberExists  = CmdletHasMember "TaskContext"
 
 if($taskContextMemberExists){
     Write-Verbose "Calling Register Environment cmdlet"
-    $environment = Register-Environment -EnvironmentName $testMachineGroup -EnvironmentSpecification $testMachineGroup -UserName $adminUserName -Password $adminPassword -TestCertificate ($testCertificate -eq "true") -Connection $connection -TaskContext $distributedTaskContext -WinRmProtocol $winRmProtocol -ResourceFilter $testMachines
+    $environment = Register-Environment -EnvironmentName $testMachineGroup -EnvironmentSpecification $testMachineGroup -UserName $adminUserName -Password $adminPassword -TestCertificate ($testCertificate -eq "true") -Connection $connection -TaskContext $distributedTaskContext -WinRmProtocol $winRmProtocol -ResourceFilter $testMachines -DoNotPersist
     Write-Verbose "Environment details $environment"
 
     Write-Verbose "Calling Deploy test agent cmdlet"

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 21
+        "Patch": 22
     },
     "demands": [
 

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 21
+    "Patch": 22
   },
   "demands": [],
   "minimumAgentVersion": "1.95.0",


### PR DESCRIPTION
Issue: Use azure resource group task to get VMs using the output variable. Use this output variable in sub-sequent DTA tasks with filtering resources. The build is expected to get the filtered machines where as it fails to get filtered machines second time in the build definition

Fix: DTL Team requires 'DoNotPersist' flag to set, so that they can clone the machine information and make it available for all subsequent tasks with filtering