### PR TITLE
Users/nigurr/fix vs test version handling m96

### DIFF
--- a/Tasks/VsTest/Helpers.ps1
+++ b/Tasks/VsTest/Helpers.ps1
@@ -25,6 +25,10 @@ function IsVisualStudio2015Update1OrHigherInstalled {
     param(
         [string]$vsTestVersion
     )
+
+    if ([string]::IsNullOrWhiteSpace($vsTestVersion)){
+        $vsTestVersion = Locate-VSVersion
+    }
     
     $version = [int]($vsTestVersion)
     if($version -ge 14)
@@ -90,5 +94,35 @@ function SetupRunSettingsFileForParallel {
         return $tempFile
     }
     return $runSettingsFilePath
+}
+
+function Get-SubKeysInFloatFormat($keys)
+{
+    $targetKeys = @()      # New array
+    foreach ($key in $keys)
+    {
+        $targetKeys += $key -as [decimal]
+    }
+
+    return $targetKeys
+}
+
+function Locate-VSVersion()
+{
+    #Find the latest version
+    $regPath = "HKLM:\SOFTWARE\Microsoft\VisualStudio"
+    if (-not (Test-Path $regPath))
+    {
+        return $null
+    }
+    
+    $keys = Get-Item $regPath | %{$_.GetSubKeyNames()} -ErrorAction SilentlyContinue
+    $version = Get-SubKeysInFloatFormat $keys | Sort-Object -Descending | Select-Object -First 1
+
+    if ([string]::IsNullOrWhiteSpace($version))
+    {
+        return $null
+    }
+    return $version
 }
 

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 30
+    "Patch": 31
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTest/task.loc.json
+++ b/Tasks/VsTest/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 30
+    "Patch": 31
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
Issue:   Run Parallel Test execution doesn't identify the Visual Studio version installed in the machine if user opts for Test Execution as "latest" in VSTest task.