### PR TITLE
Fixed issue in setting up the default value

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 21
+        "Patch": 22
     },
     "demands": [
 
@@ -69,7 +69,7 @@
             "type": "radio",
             "label": "Protocol",
             "required": false,
-            "defaultValue": "Https",
+            "defaultValue": "",
             "options": {
                 "Http": "HTTP",
                 "Https": "HTTPS"

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 21
+    "Patch": 22
   },
   "demands": [],
   "minimumAgentVersion": "1.95.0",
@@ -67,7 +67,7 @@
       "type": "radio",
       "label": "ms-resource:loc.input.label.winRmProtocol",
       "required": false,
-      "defaultValue": "Https",
+      "defaultValue": "",
       "options": {
         "Http": "HTTP",
         "Https": "HTTPS"


### PR DESCRIPTION
Fixed issue in setting up the default value of Deploy Test Agent WinRM Port. If default value is set in task.json, for the old definition this will be auto pre-filled, which can break old def.