### PR TITLE
Fixed problem setting deployment Id

### DIFF
--- a/Tasks/AzureWebPowerShellDeployment/Publish-AzureWebDeployment.ps1
+++ b/Tasks/AzureWebPowerShellDeployment/Publish-AzureWebDeployment.ps1
@@ -147,7 +147,7 @@ if($azureWebSite) {
         
         $deploymentId = Get-TaskVariable $distributedTaskContext "release.releaseUri" #let's use releaseUri as unique deploymentId in release context
         if([string]::IsNullOrEmpty($deploymentId)) {
-            $deploymentId = Get-TaskVariable $distributedTaskContext "build.sourceVersion" #let's use commitId as unique deploymentId in build context
+            $deploymentId = Get-TaskVariable $distributedTaskContext "build.buildUri" #let's use buildUri as unique deploymentId in build context
         }
         if([string]::IsNullOrEmpty($deploymentId)) {
             #No point in proceeding further
@@ -155,10 +155,7 @@ if($azureWebSite) {
             Return
         }
         
-        $message = Get-TaskVariable $distributedTaskContext "build.sourceVersionMessage"
-        if([string]::IsNullOrEmpty($message)) {
-            $message = Get-LocalizedString -Key "Updating deployment history for deployment {0}" -ArgumentList $deploymentId
-        }
+        $message = Get-LocalizedString -Key "Updating deployment history for deployment {0}" -ArgumentList $deploymentId
         
         $buildId = Get-TaskVariable $distributedTaskContext "build.buildId"
         

--- a/Tasks/AzureWebPowerShellDeployment/Publish-AzureWebDeployment.ps1
+++ b/Tasks/AzureWebPowerShellDeployment/Publish-AzureWebDeployment.ps1
@@ -145,10 +145,10 @@ if($azureWebSite) {
             }
         }
         
-        $deploymentId = Get-TaskVariable $distributedTaskContext "build.sourceVersion" #let's use commitId as unique deploymentId in build context
+        $deploymentId = Get-TaskVariable $distributedTaskContext "release.releaseUri" #let's use releaseUri as unique deploymentId in release context
         if([string]::IsNullOrEmpty($deploymentId)) {
-            $deploymentId = Get-TaskVariable $distributedTaskContext "release.releaseUri" #let's use releaseUri as unique deploymentId in release context
-        }        
+            $deploymentId = Get-TaskVariable $distributedTaskContext "build.sourceVersion" #let's use commitId as unique deploymentId in build context
+        }
         if([string]::IsNullOrEmpty($deploymentId)) {
             #No point in proceeding further
             Write-Warning (Get-LocalizedString -Key "Cannot update deployment status, unique deploymentId cannot be retrieved")  

--- a/Tasks/AzureWebPowerShellDeployment/task.json
+++ b/Tasks/AzureWebPowerShellDeployment/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 26
+    "Patch": 27
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureWebPowerShellDeployment/task.loc.json
+++ b/Tasks/AzureWebPowerShellDeployment/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 26
+    "Patch": 27
   },
   "demands": [
     "azureps"


### PR DESCRIPTION
It appears the intention was to use the Commit Id when running this task from a build, and the Release URI when running from a release.  The problem is the logic was a little off.  It was assuming the build.sourceVersion would be empty when running from a release, but that's not true (at least not if you have a release definition that is linked to a build).

Changed it to first check if releaseUri is set and if so use that for deploymentId (this should not be set in a build context), and if not then use the build.sourceVersion as the deployment Id.

Related to Issue #1311