### PR TITLE
Missing DTL Import DLL in DTA Task for Register-Environment

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/DeployTestAgent.ps1
+++ b/Tasks/DeployVisualStudioTestAgent/DeployTestAgent.ps1
@@ -68,6 +68,7 @@ Write-Verbose "VerifyTestMachinesAreInUseScriptLocation = $verifyTestMachinesAre
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Internal"
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.DTA"
+import-module "Microsoft.TeamFoundation.DistributedTask.Task.DevTestLabs"
 
 Write-Verbose "Getting the connection object"
 $connection = Get-VssConnection -TaskContext $distributedTaskContext

--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 22
+        "Patch": 23
     },
     "demands": [
 

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 22
+    "Patch": 23
   },
   "demands": [],
   "minimumAgentVersion": "1.95.0",


### PR DESCRIPTION
Issue: Missing DTL Import DLL in DTA Task for Register-Environment cmdlet.
Fix: Importing the DTL dll explicitly in DTA Task