### PR TITLE
IIS Web Deploy: ability to skip website/app pool creation during deploy

### DIFF
--- a/Tasks/IISWebAppDeployment/DeployIISWebApp.ps1
+++ b/Tasks/IISWebAppDeployment/DeployIISWebApp.ps1
@@ -9,6 +9,7 @@
     [string]$webDeployPackage,
     [string]$webDeployParamFile,
     [string]$overRideParams,
+	[string]$createWebSite,
     [string]$webSiteName,    
     [string]$webSitePhysicalPath,
     [string]$webSitePhysicalPathAuth,
@@ -24,6 +25,7 @@
     [string]$hostNameWithSNI,
     [string]$serverNameIndication,
     [string]$sslCertThumbPrint,
+	[string]$createAppPool,
     [string]$appPoolName,
     [string]$dotNetVersion,
     [string]$pipeLineMode,
@@ -62,10 +64,12 @@ Write-Verbose "webDeployParamFile = $webDeployParamFile" -Verbose
 Write-Verbose "overRideParams = $overRideParams" -Verbose
 Write-Verbose "deployInParallel = $deployInParallel" -Verbose
 
+Write-Verbose "createWebSite = $createWebSite" -Verbose
 Write-Verbose "webSiteName = $webSiteName" -Verbose
 Write-Verbose "webSitePhysicalPath = $webSitePhysicalPath" -Verbose
 Write-Verbose "webSitePhysicalPathAuth = $webSitePhysicalPathAuth" -Verbose
 Write-Verbose "webSiteAuthUserName = $webSiteAuthUserName" -Verbose
+
 Write-Verbose "addBinding = $addBinding" -Verbose
 Write-Verbose "assignDuplicateBinding = $assignDuplicateBinding" -Verbose
 Write-Verbose "protocol = $protocol" -Verbose
@@ -116,7 +120,7 @@ if(![string]::IsNullOrWhiteSpace($webSiteName))
 $overRideParams = $overRideParams.Replace('"', '''')
 
 $msDeployOnTargetMachinesBlock = Get-Content  ./MsDeployOnTargetMachines.ps1 | Out-String
-$scriptArgs = " -WebDeployPackage `"$webDeployPackage`" -WebDeployParamFile `"$webDeployParamFile`" -OverRideParams `"$overRideParams`"  -WebSiteName `"$webSiteName`" -WebSitePhysicalPath `"$webSitePhysicalPath`" -WebSitePhysicalPathAuth `"$webSitePhysicalPathAuth`" -WebSiteAuthUserName $webSiteAuthUserName -WebSiteAuthUserPassword $webSiteAuthUserPassword -AddBinding $addBinding -AssignDuplicateBinding $assignDuplicateBinding -Protocol $protocol -IpAddress `"$ipAddress`" -Port $port -HostName $hostName -ServerNameIndication $serverNameIndication -SslCertThumbPrint $sslCertThumbPrint -AppPoolName `"$appPoolName`" -DotNetVersion `"$dotNetVersion`" -PipeLineMode $pipeLineMode -AppPoolIdentity $appPoolIdentity -AppPoolUsername `"$appPoolUsername`" -AppPoolPassword `"$appPoolPassword`" -AppCmdCommands `"$appCmdCommands`""
+$scriptArgs = " -WebDeployPackage `"$webDeployPackage`" -WebDeployParamFile `"$webDeployParamFile`" -OverRideParams `"$overRideParams`"  -WebSiteName `"$webSiteName`" -WebSitePhysicalPath `"$webSitePhysicalPath`" -WebSitePhysicalPathAuth `"$webSitePhysicalPathAuth`" -WebSiteAuthUserName $webSiteAuthUserName -WebSiteAuthUserPassword $webSiteAuthUserPassword -AddBinding $addBinding -AssignDuplicateBinding $assignDuplicateBinding -Protocol $protocol -IpAddress `"$ipAddress`" -Port $port -HostName $hostName -ServerNameIndication $serverNameIndication -SslCertThumbPrint $sslCertThumbPrint -AppPoolName `"$appPoolName`" -DotNetVersion `"$dotNetVersion`" -PipeLineMode $pipeLineMode -AppPoolIdentity $appPoolIdentity -AppPoolUsername `"$appPoolUsername`" -AppPoolPassword `"$appPoolPassword`" -AppCmdCommands `"$appCmdCommands`" -CreateWebsite `"$createWebsite`" -CreateAppPool `"$createAppPool`""
 
 Write-Verbose "MsDeployOnTargetMachines Script Arguments : $scriptArgs" -Verbose
 Write-Output ( Get-LocalizedString -Key "Starting deployment of IIS Web Deploy Package : {0}" -ArgumentList $webDeployPackage)

--- a/Tasks/IISWebAppDeployment/DeployIISWebApp.ps1
+++ b/Tasks/IISWebAppDeployment/DeployIISWebApp.ps1
@@ -78,6 +78,7 @@ Write-Verbose "port = $port" -Verbose
 Write-Verbose "hostName = $hostName" -Verbose
 Write-Verbose "serverNameIndication = $serverNameIndication" -Verbose
 
+Write-Verbose "createAppPool = $createAppPool" -Verbose
 Write-Verbose "appPoolName = $appPoolName" -Verbose
 Write-Verbose "dotNetVersion = $dotNetVersion" -Verbose
 Write-Verbose "pipeLineMode = $pipeLineMode" -Verbose
@@ -103,6 +104,16 @@ $appPoolName = $appPoolName.Trim('"', ' ')
 $appPoolUsername = $appPoolUsername.Trim()
 
 $appCmdCommands = $appCmdCommands.Replace('"', '`"')
+
+if ($createWebsite -ieq "true" -and [string]::IsNullOrWhiteSpace($webSiteName))
+{
+	throw "WebSiteName cannot be empty if you want to create or update the target website."
+}
+
+if ($createAppPool -ieq "true" -and [string]::IsNullOrWhiteSpace($appPoolName))
+{
+	throw "AppPoolName cannot be empty if you want to create or update the target app pool."
+}
 
 if(![string]::IsNullOrWhiteSpace($webSiteName))
 {

--- a/Tasks/IISWebAppDeployment/task.json
+++ b/Tasks/IISWebAppDeployment/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 0,
-    "Patch": 9
+    "Minor": 1,
+    "Patch": 0
   },
   "demands": [
   ],
@@ -112,16 +112,7 @@
       "required": false,
       "groupName": "deployment",
       "defaultValue": "",
-      "helpMarkDown": "Parameters specified here will override the parameters in the MSDeploy zip file and the Parameter file. To override more than one parameter use line separator, e.g., <br/> \"IIS Web Application Name\"=\"Fabrikam\" <br/> \"ConnectionString\"=\"Server=localhost;Database=Fabrikam;\""
-    },
-    {
-      "name": "CreateWebSite",
-      "type": "boolean",
-      "label": "Create or Update Website",
-      "required": false,
-      "groupName": "website",
-      "defaultValue": "false",
-      "helpMarkDown": "Select the option to create a website or to update an existing website."
+      "helpMarkDown": "Parameters specified here will override the parameters in the MSDeploy zip file and the Parameter file. To override more than one parameter use line separator, e.g., <br/> \"IIS Web Application Name\"=\"Fabrikam\" <br/> \"ConnectionString\"=\"Server=localhost;Database=Fabrikam;"
     },
     {
       "name": "WebSiteName",
@@ -130,8 +121,16 @@
       "required": true,
       "groupName": "website",
       "defaultValue": "",
-      "visibleRule": "CreateWebSite = true",
-      "helpMarkDown": "Name of the IIS website that will be created if it does not exist, or it will be updated if it is already present on the IIS server. The name of the website should be same as that specified in the web deploy zip package file. If a Parameter file and override Parameters setting is also specified, then the name of the website should be same as that in the override Parameters setting."
+      "helpMarkDown": "Name of the target IIS website. The name of the website should be same as that specified in the web deploy zip package file. If a Parameter file and override Parameters setting is also specified, then the name of the website should be same as that in the override Parameters setting."
+    },
+    {
+      "name": "CreateWebSite",
+      "type": "boolean",
+      "label": "Create or Update Website",
+      "required": false,
+      "groupName": "website",
+      "defaultValue": "false",
+      "helpMarkDown": "Select the option to create a website or to update an existing website. If not selected, then the target website must already exist."
     },
     {
       "name": "WebSitePhysicalPath",
@@ -288,7 +287,7 @@
       "required": false,
       "groupName": "applicationPool",
       "defaultValue": "false",
-      "helpMarkDown": "Select the option to create an application pool or to update an existing application pool."
+      "helpMarkDown": "Select the option to create an application pool or to update an existing application pool. If not selected, the existing app pool for the target site/application will not be modified."
     },
     {
       "name": "AppPoolName",


### PR DESCRIPTION
Adds ability for person configuring the on-prem IIS Web Deploy task to NOT modify the target website/app pool if they are already in place or created during another step of the deploy process.