### PR TITLE
Add ability to skip VsTest task based on platform/configuration filter.

### DIFF
--- a/Tasks/VsTest/Helpers.ps1
+++ b/Tasks/VsTest/Helpers.ps1
@@ -29,7 +29,7 @@ function IsVisualStudio2015Update1OrHigherInstalled {
     if ([string]::IsNullOrWhiteSpace($vsTestVersion)){
         $vsTestVersion = Locate-VSVersion
     }
-    
+
     $version = [int]($vsTestVersion)
     if($version -ge 14)
     {
@@ -126,3 +126,47 @@ function Locate-VSVersion()
 	return $version
 }
 
+<#
+    .SYNOPSIS
+    Check wether or not to skip a test run.
+    
+    
+    .DESCRIPTION
+    
+    Given a string containing configuration|platform permutations, and the current configuration and platform being run, determine whether
+    or not to actually run the tests. All string comparisons are case insensitive.
+    
+    .PARAMETER skipConfigPlatformPermutations
+    Comma or semicolon delimited string containing configuration platform permutations. String should look like so: "Debug|ARM,Release|ARM,Profile|x86".
+    .PARAMETER config
+    Current build configuration being tested against.
+    .PARAMETER platform
+    Current build platform being tested against.
+#>
+function SkipTestsForConfigurationPlatform  {
+    [cmdletbinding()]
+    [OutputType([System.Boolean])]
+    param(
+        [string]$skipConfigPlatformPermutations,
+        [string]$config,
+        [string]$platform
+    )
+
+    [System.Boolean]$skip = $false
+        
+    # Test to see if we need to do anything at all based on the skipConfigPlatformPermutations setting...
+    if ($skipConfigPlatformPermutations)
+    {
+        Write-Verbose "Checking if Config:$config and Platform:$platform is in the list of skip-combos '$skipConfigPlatformPermutations'"
+        $matchConfigPlat = $skipConfigPlatformPermutations -split "[,;]" | Where-Object -FilterScript { $_ -ieq "$config|$platform" }
+        $skip = ($matchConfigPlat -ne $null)
+         
+        if ($skip)
+        {
+            #Write-Host "Skipping this Configuration|Platform combination as per the 'Skip Configuration|Platform' setting."
+            Write-Verbose "Skipping Configuration|Platform = $config|$platform (matches '$matchConfigPlat')"
+        }
+    }
+    
+    return $skip
+}

--- a/Tasks/VsTest/VSTest.ps1
+++ b/Tasks/VsTest/VSTest.ps1
@@ -12,8 +12,9 @@ param(
     [string]$platform,
     [string]$configuration,
     [string]$publishRunAttachments,
-    [string]$runInParallel
-    )
+    [string]$runInParallel,
+    [string]$skipConfigurationPlatform
+)
 
 Write-Verbose "Entering script VSTest.ps1"
 Write-Verbose "vsTestVersion = $vsTestVersion"
@@ -28,6 +29,8 @@ Write-Verbose "testRunTitle = $testRunTitle"
 Write-Verbose "platform = $platform"
 Write-Verbose "configuration = $configuration"
 Write-Verbose "publishRunAttachments = $publishRunAttachments"
+Write-Verbose "runInParallel = $runInParallel"
+Write-Verbose "skipConfigurationPlatform = $skipConfigurationPlatform"
 
 # Import the Task.Common and Task.Internal dll that has all the cmdlets we need for Build
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Internal"
@@ -36,6 +39,13 @@ import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.TestResults"
 
 . $PSScriptRoot\Helpers.ps1
+
+if (SkipTestsForConfigurationPlatform -skipConfigPlatformPermutations $skipConfigurationPlatform -config $configuration -platform $platform)
+{
+    # exit the script early - no need to continue on.
+    Write-Host "##vso[task.complete result=Skipped;]Skipped running VsTest task for '$configuration|$platform'"    
+    exit
+}
 
 if (!$testAssembly)
 {

--- a/Tasks/VsTest/task.json
+++ b/Tasks/VsTest/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 34
+    "Patch": 35
   },
   "demands": [
     "vstest"
@@ -121,6 +121,15 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "Other Console options that can be passed to vstest.console.exe. Click on the help link below for more details.",
+      "groupName": "advancedExecutionOptions"
+    },
+    {
+      "name": "skipConfigurationPlatform",
+      "type": "string",
+      "label": "Skip Configuration|Platform",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Configuration|Platform combinations to skip running tests for, separated by commas (ie. Release|x86,Release|Any CPU).",
       "groupName": "advancedExecutionOptions"
     },
     {

--- a/Tests/L0/VsTest/SkipConfigurationPlatforms.ps1
+++ b/Tests/L0/VsTest/SkipConfigurationPlatforms.ps1
@@ -1,0 +1,71 @@
+[cmdletbinding()]
+param()
+
+. $PSScriptRoot\..\..\lib\Initialize-Test.ps1
+
+# Load up the VsTest helpers suite
+. $PSScriptRoot\..\..\..\Tasks\VsTest\Helpers.ps1
+$testCases = @{"(Base case) Debug ARM is skipped"=@{
+                   p="ARM";c="Debug";r=$true
+               };
+                "(Base case) Release ARM is skipped"=@{
+                   p="ARM";c="Release";r=$true
+               };
+                "(Base case) Profile x86 is skipped"=@{
+                   p="x86";c="Profile";r=$true
+               };
+                "(Base case) Release x86 is not skipped"=@{
+                   p="x86";c="Release";r=$false
+               };
+                "(Case sensitivity) pROfiLe X86 is skipped"=@{
+                   p="X86";c="pROfiLe";r=$true
+               };
+                "(Invalid param) Release 'no platform given' is not skipped"=@{
+                   p="";c="Release";r=$false
+               };
+                "(Invalid param) 'no config given' ARM is not skipped"=@{
+                   p="ARM";c="";r=$false
+               };
+              }
+
+$skipPlatConfig="Debug|ARM,Release|ARM,Profile|x86"
+$testCases.Keys | ForEach-Object {
+    
+    Write-Verbose "Test case ""$PSItem"":"
+    $testPlatform = $testCases[$PSItem].p
+    $testConfig = $testCases[$PSItem].c
+    $expectedResult = $testCases[$PSItem].r
+    Write-Verbose "   platform:$testPlatform"
+    Write-Verbose "   config:$testConfig"
+    Write-Verbose "   expectedResult:$expectedResult"
+        
+    $skip = SkipTestsForConfigurationPlatform -skipConfigPlatformPermutations $skipPlatConfig -config $testConfig -platform $testPlatform
+    
+    Write-Verbose "Actual output from check function: $skip"
+    
+    Assert-AreEqual $skip $expectedResult
+}
+
+# Ensure the actual VsTest.ps1 script also exits early
+Register-Mock Get-TaskVariable { $sourcesDirectory } -- -Context $distributedTaskContext -Name "Build.SourcesDirectory"
+
+$splat = @{
+    'vsTestVersion' = 'vsTestVersion'
+    'testAssembly' = 'bogustestassembly' 
+    'testFiltercriteria' = 'testFiltercriteria' 
+    'runSettingsFile' = 'runSettingsFile' 
+    'codeCoverageEnabled' = 'codeCoverageEnabled'
+    'pathtoCustomTestAdapters' = 'pathtoCustomTestAdapters'
+    'overrideTestrunParameters' = 'overrideTestrunParameters'
+    'otherConsoleOptions' = 'otherConsoleOptions'
+    'testRunTitle' = 'testRunTitle'
+    'platform' = 'ARM'
+    'configuration' = 'Debug'
+    'publishRunAttachments' = 'publishRunAttachments'
+    'runInParallel' = 'runInParallel'
+    'skipConfigurationPlatform' = $skipPlatConfig
+}
+
+& $PSScriptRoot\..\..\..\Tasks\VsTest\VsTest.ps1 @splat
+
+Assert-WasCalled Get-TaskVariable -Times 0

--- a/Tests/L0/VsTest/_suite.ts
+++ b/Tests/L0/VsTest/_suite.ts
@@ -70,5 +70,8 @@ describe('VsTest Suite', function () {
          it('ValidateTestAssembliesAreSplit) tests if the input test assembiles are properly passed to cmdlet', (done) => {
             psm.runPS(path.join(__dirname, 'ValidateTestAssembliesAreNotSplit.ps1'), done);
         })
+        it('(SkipConfigurationPlatforms) vstest task is skipped or not as per input', (done) => {
+            psm.runPS(path.join(__dirname, 'SkipConfigurationPlatforms.ps1'), done);
+        })
     }
 });

--- a/Tests/lib/vsts-task-lib/toolrunner.ts
+++ b/Tests/lib/vsts-task-lib/toolrunner.ts
@@ -44,10 +44,10 @@ export class ToolRunner extends events.EventEmitter {
     constructor(toolPath) {
         debug('toolRunner toolPath: ' + toolPath);
 
+        super();
         this.toolPath = toolPath;
         this.args = [];
         this.silent = false;
-        super();
     }
 
     public toolPath: string;


### PR DESCRIPTION
Create a new input into the VsTest task that allows the build to skip VsTest for specified configuration|platform combinations.

Proposed solution for issue 1353: "VsTest in parallel builds doesn't make sense for Windows Universal Apps that build non-Windows-server platforms such as ARM"

#1353 