### PR TITLE
IIS Task Fix

### DIFF
--- a/Tasks/IISWebAppDeployment/MsDeployOnTargetMachines.ps1
+++ b/Tasks/IISWebAppDeployment/MsDeployOnTargetMachines.ps1
@@ -365,7 +365,7 @@ function Add-SslCert
         $addCertCmd = [string]::Format("netsh http add sslcert ipport=0.0.0.0:{0} certhash={1} appid={{{2}}}", $port, $certhash, [System.Guid]::NewGuid().toString())
     }
 
-    $isItSameCert = $result.Get(5).Contains([string]::Format("{0}", $certhash))
+    $isItSameCert = $result.Get(5).Contains([string]::Format("{0}", $certhash.ToLower()))
 
     if($isItSameBinding -and $isItSameCert)
     {

--- a/Tasks/IISWebAppDeployment/MsDeployOnTargetMachines.ps1
+++ b/Tasks/IISWebAppDeployment/MsDeployOnTargetMachines.ps1
@@ -365,7 +365,7 @@ function Add-SslCert
         $addCertCmd = [string]::Format("netsh http add sslcert ipport=0.0.0.0:{0} certhash={1} appid={{{2}}}", $port, $certhash, [System.Guid]::NewGuid().toString())
     }
 
-    $isItSameCert = $result.Get(5).Contains([string]::Format("{0}", $certhash.ToLower()))
+    $isItSameCert = $result.Get(5).ToLower().Contains([string]::Format("{0}", $certhash.ToLower()))
 
     if($isItSameBinding -and $isItSameCert)
     {

--- a/Tasks/IISWebAppDeployment/task.json
+++ b/Tasks/IISWebAppDeployment/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 11
+    "Patch": 12
   },
   "demands": [
   ],

--- a/Tasks/IISWebAppDeployment/task.loc.json
+++ b/Tasks/IISWebAppDeployment/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 11
+    "Patch": 12
   },
   "demands": [],
   "minimumAgentVersion": "1.91.0",


### PR DESCRIPTION
When certificate thumbprint is provided as capital letters in UI, our
task fails to find the binding already exists or not.