### PR TITLE
Updated toolrunner to work with TypeScript 1.8.7

### DIFF
--- a/Tests/lib/vsts-task-lib/toolrunner.ts
+++ b/Tests/lib/vsts-task-lib/toolrunner.ts
@@ -44,10 +44,10 @@ export class ToolRunner extends events.EventEmitter {
     constructor(toolPath) {
         debug('toolRunner toolPath: ' + toolPath);
 
+        super();
         this.toolPath = toolPath;
         this.args = [];
         this.silent = false;
-        super();
     }
 
     public toolPath: string;


### PR DESCRIPTION
During testing of PR #1293 it was discovered that toolrunner.ts doesn't compile in TypeScript 1.8.7.

This should fix that.