### PR TITLE
NuGetPublisher, explicitly pass parameters to GetConnectionDataAsync

### DIFF
--- a/Tasks/NugetPublisher/NuGetPublisher.ps1
+++ b/Tasks/NugetPublisher/NuGetPublisher.ps1
@@ -236,7 +236,11 @@ try
                     [uri]$env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI,
                     $cred)
 
-                $connectionData = $locationClient.GetConnectionDataAsync("None", -1).Result
+                $connectionData = $locationClient.GetConnectionDataAsync(
+                    [Microsoft.VisualStudio.Services.WebApi.ConnectOptions]::None,
+                    -1,
+                    [System.Threading.CancellationToken]::None,
+                    $null).Result
 
                 $builderDisplayName = $connectionData.AuthorizedUser.DisplayName
                 $builderAccountName = $connectionData.AuthorizedUser.Properties["Account"]

--- a/Tasks/NugetPublisher/task.json
+++ b/Tasks/NugetPublisher/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 46
+        "Patch": 47
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/Tasks/NugetPublisher/task.loc.json
+++ b/Tasks/NugetPublisher/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 46
+    "Patch": 47
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [


### PR DESCRIPTION
This is a fix for #1402 