### PR TITLE
version bump up

### DIFF
--- a/Tasks/DeployVisualStudioTestAgent/task.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 25
+        "Patch": 26
     },
     "demands": [
 

--- a/Tasks/DeployVisualStudioTestAgent/task.loc.json
+++ b/Tasks/DeployVisualStudioTestAgent/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 25
+    "Patch": 26
   },
   "demands": [],
   "minimumAgentVersion": "1.97.0",


### PR DESCRIPTION
Version in release/M97 is 26. Hence updated the version in master. 
while the fix went to release/M97 is specific to the sprint 97 and is already updated in all hosted agents, just updating the version number.