### PR TITLE
removing verbose switch from Write-Verbose flags in remote pas task

### DIFF
--- a/Tasks/PowerShellOnTargetMachines/PowerShellOnTargetMachines.ps1
+++ b/Tasks/PowerShellOnTargetMachines/PowerShellOnTargetMachines.ps1
@@ -133,9 +133,9 @@ function Get-ResourceWinRmConfig
 
     if(-not $isAgentVersion97)
     {
-        Write-Verbose "Starting Get-Environment cmdlet call on environment name: $environmentName" -Verbose
+        Write-Verbose "Starting Get-Environment cmdlet call on environment name: $environmentName"
         $environment = Get-Environment -environmentName $environmentName -TaskContext $distributedTaskContext
-        Write-Verbose "Completed Get-Environment cmdlet call on environment name: $environmentName" -Verbose
+        Write-Verbose "Completed Get-Environment cmdlet call on environment name: $environmentName"
     }
     
     if($protocol -eq "HTTPS")


### PR DESCRIPTION
with recent porting of some commits from other branch, 2 instances of Write-Verbose calls got copied with -Verbose switch. Removed that switch