### PR TITLE
NuGetPublisher check URI and ignore old NuGet.config file

### DIFF
--- a/Tasks/NugetPublisher/task.json
+++ b/Tasks/NugetPublisher/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 49
+        "Patch": 50
     },
     "minimumAgentVersion": "1.83.0",
     "groups": [

--- a/Tasks/NugetPublisher/task.loc.json
+++ b/Tasks/NugetPublisher/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 49
+    "Patch": 50
   },
   "minimumAgentVersion": "1.83.0",
   "groups": [


### PR DESCRIPTION
This change will ignore loading any present NuGet.config file and re-write it with a newly generated one. The feed URI will now be checked and the task will fail if an invalid path is used.