### PR TITLE
Rollback AzurePS to AZPS handler.

### DIFF
--- a/Tasks/AzurePowerShell/task.json
+++ b/Tasks/AzurePowerShell/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 16
+        "Patch": 17
     },
     "demands" : [
         "azureps"
@@ -69,9 +69,6 @@
     ],
     "instanceNameFormat": "Azure PowerShell script: $(ScriptPath)",
     "execution": {
-        "PowerShell3": {
-            "target": "AzurePowerShell.ps1"
-        },
         "AzurePowerShell": {
             "target": "$(currentDirectory)\\AzurePowerShell-Legacy.ps1",
             "argumentFormat": "",

--- a/Tasks/AzurePowerShell/task.loc.json
+++ b/Tasks/AzurePowerShell/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 16
+    "Patch": 17
   },
   "demands": [
     "azureps"
@@ -69,9 +69,6 @@
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "execution": {
-    "PowerShell3": {
-      "target": "AzurePowerShell.ps1"
-    },
     "AzurePowerShell": {
       "target": "$(currentDirectory)\\AzurePowerShell-Legacy.ps1",
       "argumentFormat": "",


### PR DESCRIPTION
Is the fix already in master?  If not, link the bug tracking that work.
Yes.

What testing was done?
Deploy fix. Verify old task handler is picked instead of the new one.

Does this fix change the AT/DT contract?
No

Does this fix include any database servicing changes?
No. Config change only to deploy the task hotfix.

Were tests added to cover this to make sure it doesn't regress?  If not, link a bug or user story tracking that work.
No. This is a rollback to use the previous implementation. I need to find a proper fix.